### PR TITLE
Make sure to set bridge port UP

### DIFF
--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -133,6 +133,15 @@ func attachIfaceToBridge(hostIfaceName string, contIfaceName string, brName stri
 		return fmt.Errorf("failed to attach veth to bridge: %s", string(output[:]))
 	}
 
+	hostLink, err := netlink.LinkByName(hostIfaceName)
+	if err != nil {
+		return err
+	}
+
+	if err := netlink.LinkSetUp(hostLink); err != nil {
+		return err
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
We need to set bridge ports explicitly UP in order to be able to ping between two pods.