### PR TITLE
initialize random seed for random number generator

### DIFF
--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -16,10 +16,10 @@
 package plugin
 
 import (
+	"crypto/rand"
 	"encoding/json"
 	"fmt"
 	"log"
-	"math/rand"
 	"net"
 	"os/exec"
 	"runtime"


### PR DESCRIPTION
Until now, the seed was static and always produced the same MAC
address. With this change, random seed is taken from
time.Now().UnixNano().