### PR TITLE
disable stdci images deployment

### DIFF
--- a/automation/check-merged.sh
+++ b/automation/check-merged.sh
@@ -17,4 +17,5 @@ main() {
     make docker-push
 }
 
-[[ "${BASH_SOURCE[0]}" == "$0" ]] && main "$@"
+# We use Travis to deploy built images
+# [[ "${BASH_SOURCE[0]}" == "$0" ]] && main "$@"


### PR DESCRIPTION
Without this patch, we use both Travis and STD-CI to deploy images.