### PR TITLE
Add selector to ovs-vsctl template

### DIFF
--- a/examples/openshift-ovs-vsctl.yml
+++ b/examples/openshift-ovs-vsctl.yml
@@ -7,6 +7,10 @@ metadata:
     tier: node
     app: ovs-cni
 spec:
+  selector:
+    matchLabels:
+      tier: node
+      app: ovs-cni
   template:
     metadata:
       labels:


### PR DESCRIPTION
Failed to apply ovs-vsctl with error:
`selector` does not match template `labels`