### PR TITLE
fix empty resource reporting

### DIFF
--- a/pkg/marker/marker.go
+++ b/pkg/marker/marker.go
@@ -67,8 +67,11 @@ func getAvailableResources(ovsSocket string) (map[string]bool, error) {
 	}
 
 	availableResources := make(map[string]bool)
-	for _, bridgeName := range strings.Split(strings.TrimSpace(string(outputRaw)), "\n") {
-		availableResources[bridgeName] = true
+
+	if len(outputRaw) > 0 {
+		for _, bridgeName := range strings.Split(strings.TrimSpace(string(outputRaw)), "\n") {
+			availableResources[bridgeName] = true
+		}
 	}
 
 	return availableResources, nil


### PR DESCRIPTION
With the current code, when there are no bridges on a node,
ovs-vsctl br-list returns "" which is later split to list of
bridges [""]. In order to prevent that, we need to check length
of returned string containing list of bridges.