### PR TITLE
Fixed `make build`

### DIFF
--- a/automation/check-patch.sh
+++ b/automation/check-patch.sh
@@ -20,10 +20,10 @@ main() {
     curl -sL https://raw.githubusercontent.com/travis-ci/gimme/master/gimme | HOME=/gimme bash >> /etc/profile.d/gimme.sh
     source /etc/profile.d/gimme.sh
 
-    mkdir -p $GOPATH/src/kubevirt.io
+    mkdir -p $GOPATH/src/github.com/kubevirt
     mkdir -p $GOPATH/pkg
-    ln -s $(pwd)/ovs-cni $GOPATH/src/kubevirt.io/
-    cd $GOPATH/src/kubevirt.io/ovs-cni
+    ln -s $(pwd)/ovs-cni $GOPATH/src/github.com/kubevirt/
+    cd $GOPATH/src/github.com/kubevirt/ovs-cni
 
     echo "Run functional tests"
     exec automation/test.sh

--- a/cmd/marker/main.go
+++ b/cmd/marker/main.go
@@ -19,7 +19,7 @@ import (
 	"time"
 
 	"github.com/golang/glog"
-	"kubevirt.io/ovs-cni/pkg/marker"
+	"github.com/kubevirt/ovs-cni/pkg/marker"
 )
 
 func main() {

--- a/cmd/plugin/main.go
+++ b/cmd/plugin/main.go
@@ -18,7 +18,7 @@ import (
 	"github.com/containernetworking/cni/pkg/skel"
 	"github.com/containernetworking/cni/pkg/version"
 
-	"kubevirt.io/ovs-cni/pkg/plugin"
+	"github.com/kubevirt/ovs-cni/pkg/plugin"
 )
 
 func main() {

--- a/hack/docker-builder/rsyncd.conf
+++ b/hack/docker-builder/rsyncd.conf
@@ -5,15 +5,15 @@ reverse lookup = no
 [build]
     hosts allow = *
     read only = false
-    path = /root/go/src/kubevirt.io/ovs-cni/
+    path = /root/go/src/github.com/kubevirt/ovs-cni/
     comment = input sources
 [out]
     hosts allow = *
     read only = false
-    path = /root/go/src/kubevirt.io/ovs-cni/_out
+    path = /root/go/src/github.com/kubevirt/ovs-cni/_out
     comment = build output
 [vendor]
     hosts allow = *
     read only = false
-    path = /root/go/src/kubevirt.io/ovs-cni/vendor
+    path = /root/go/src/github.com/kubevirt/ovs-cni/vendor
     comment = vendor directory

--- a/hack/dockerized
+++ b/hack/dockerized
@@ -28,7 +28,7 @@ if [ -z "$(docker volume list | grep ${BUILDER})" ]; then
 fi
 
 # Make sure that the output directory exists
-docker run -v "${BUILDER}:/root:rw,z" --security-opt label:disable --rm ${BUILDER} mkdir -p /root/go/src/kubevirt.io/ovs-cni/_out
+docker run -v "${BUILDER}:/root:rw,z" --security-opt label:disable --rm ${BUILDER} mkdir -p /root/go/src/github.com/kubevirt/ovs-cni/_out
 
 # Start an rsyncd instance and make sure it gets stopped after the script exits
 RSYNC_CID=$(docker run -d -v "${BUILDER}:/root:rw,z" --security-opt label:disable --expose 873 -P ${BUILDER} /usr/bin/rsync --no-detach --daemon --verbose)
@@ -70,7 +70,7 @@ _rsync --delete --exclude 'cluster/**/.kubectl' --exclude 'cluster/**/.oc' --exc
 
 # Run the command
 test -t 1 && USE_TTY="-it"
-docker run --rm -v "${BUILDER}:/root:rw,z" --security-opt label:disable ${USE_TTY} -w "/root/go/src/kubevirt.io/ovs-cni" ${BUILDER} "$@"
+docker run --rm -v "${BUILDER}:/root:rw,z" --security-opt label:disable ${USE_TTY} -w "/root/go/src/github.com/kubevirt/ovs-cni" ${BUILDER} "$@"
 
 # Copy the whole kubevirt data out to get generated sources and formatting changes
 _rsync --exclude 'cluster/**/.kubectl' --exclude 'cluster/**/.oc' --exclude 'cluster/**/.kubeconfig' --exclude "_out" --exclude "vendor" --exclude ".git" "rsync://root@127.0.0.1:${RSYNCD_PORT}/build" ${KUBEVIRT_DIR}/

--- a/hack/test-dockerized.sh
+++ b/hack/test-dockerized.sh
@@ -39,4 +39,4 @@ fi
 # Build the build container
 (cd ${DOCKER_DIR} && docker build . ${BUILD_QUIET} -t ${BUILDER})
 
-docker run --rm -it --privileged --network host --cap-add ALL -v /lib/modules:/lib/modules -v `pwd`:/root/go/src/kubevirt.io/ovs-cni -w "/root/go/src/kubevirt.io/ovs-cni" ${BUILDER} make test
+docker run --rm -it --privileged --network host --cap-add ALL -v /lib/modules:/lib/modules -v `pwd`:/root/go/src/github.com/kubevirt/ovs-cni -w "/root/go/src/github.com/kubevirt/ovs-cni" ${BUILDER} make test

--- a/tests/marker_test.go
+++ b/tests/marker_test.go
@@ -22,7 +22,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1"
-	"kubevirt.io/ovs-cni/tests"
+	"github.com/kubevirt/ovs-cni/tests"
 )
 
 var _ = Describe("ovs-cni-marker", func() {


### PR DESCRIPTION
The code imports from kubevirt.io/ovs-cni, but this path is not
available:

$ go get kubevirt.io/ovs-cni
package kubevirt.io/ovs-cni: unrecognized import path
"kubevirt.io/ovs-cni" (parse https://kubevirt.io/ovs-cni?go-get=1: no
go-import meta tags ())

But if I go get github.com/kubevirt/ovs-cni and then try to build it
then I get import failures.

This patch changes imports to use github.com/kubevirt/ovs-cni paths to
fix the build.