### PR TITLE
Use `/usr/bin/env bash` instead of `/bin/bash` for build scripts

### DIFF
--- a/hack/build-func-tests.sh
+++ b/hack/build-func-tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # This file is part of the KubeVirt project
 #

--- a/hack/build-manifests.sh
+++ b/hack/build-manifests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2018 Red Hat, Inc.
 #

--- a/hack/common.sh
+++ b/hack/common.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2018 Red Hat, Inc.
 #

--- a/hack/docker-builder/entrypoint.sh
+++ b/hack/docker-builder/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 set -o pipefail
 

--- a/hack/functests.sh
+++ b/hack/functests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # This file is part of the KubeVirt project
 #

--- a/hack/get_tag.sh
+++ b/hack/get_tag.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2018 Red Hat, Inc.
 #

--- a/hack/get_version.sh
+++ b/hack/get_version.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2018 Red Hat, Inc.
 #

--- a/hack/test-dockerized.sh
+++ b/hack/test-dockerized.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # This file is part of the KubeVirt project
 #

--- a/hack/version.sh
+++ b/hack/version.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2014 The Kubernetes Authors.
 #


### PR DESCRIPTION
Not every platform has bash available through /bin/bash (for example,
nixos doesn't put it there). But /usr/bin/env method is universal.