### PR TITLE
Don't copy ovs-vsctl to system directories

### DIFF
--- a/examples/openshift-ovs-cni.yml
+++ b/examples/openshift-ovs-cni.yml
@@ -28,11 +28,11 @@ spec:
         - /bin/bash
         - -c
         - |
-          cp /usr/bin/ovs-vsctl /host/usr/bin/_ovs-vsctl
+          cp /usr/bin/ovs-vsctl /host/usr/local/bin/_ovs-vsctl
           echo '#!/usr/bin/bash
           _ovs-vsctl --db unix:///run/openvswitch/db.sock $@
-          ' > /host/usr/bin/ovs-vsctl
-          chmod +x /host/usr/bin/ovs-vsctl
+          ' > /host/usr/local/bin/ovs-vsctl
+          chmod +x /host/usr/local/bin/ovs-vsctl
         image: docker.io/openshift/origin-node:v3.10.0-rc.0
         imagePullPolicy: IfNotPresent
         resources:
@@ -45,8 +45,8 @@ spec:
         securityContext:
           privileged: true
         volumeMounts:
-        - name: usrbin
-          mountPath: /host/usr/bin
+        - name: localbin
+          mountPath: /host/usr/local/bin
       containers:
       - name: ovs-cni-plugin
         image: quay.io/kubevirt/ovs-cni-plugin:latest
@@ -82,9 +82,9 @@ spec:
               fieldRef:
                 fieldPath: spec.nodeName
       volumes:
-        - name: usrbin
+        - name: localbin
           hostPath:
-            path: /usr/bin
+            path: /usr/local/bin
         - name: cnibin
           hostPath:
             path: /opt/cni/bin

--- a/manifests/openshift-ovs-cni.yml.in
+++ b/manifests/openshift-ovs-cni.yml.in
@@ -29,7 +29,7 @@ spec:
         - -c
         - |
           cp /usr/bin/ovs-vsctl /host/usr/local/bin/_ovs-vsctl
-          echo '#!/usr/bin/bash
+          echo '#!/bin/sh
           _ovs-vsctl --db unix:///run/openvswitch/db.sock $@
           ' > /host/usr/local/bin/ovs-vsctl
           chmod +x /host/usr/local/bin/ovs-vsctl

--- a/manifests/openshift-ovs-cni.yml.in
+++ b/manifests/openshift-ovs-cni.yml.in
@@ -28,11 +28,11 @@ spec:
         - /bin/bash
         - -c
         - |
-          cp /usr/bin/ovs-vsctl /host/usr/bin/_ovs-vsctl
+          cp /usr/bin/ovs-vsctl /host/usr/local/bin/_ovs-vsctl
           echo '#!/usr/bin/bash
           _ovs-vsctl --db unix:///run/openvswitch/db.sock $@
-          ' > /host/usr/bin/ovs-vsctl
-          chmod +x /host/usr/bin/ovs-vsctl
+          ' > /host/usr/local/bin/ovs-vsctl
+          chmod +x /host/usr/local/bin/ovs-vsctl
         image: ${OPENSHIFT_NODE_IMAGE_REPO}/${OPENSHIFT_NODE_IMAGE_NAME}:${OPENSHIFT_NODE_IMAGE_VERSION}
         imagePullPolicy: ${OPENSHIFT_NODE_IMAGE_PULL_POLICY}
         resources:
@@ -45,8 +45,8 @@ spec:
         securityContext:
           privileged: true
         volumeMounts:
-        - name: usrbin
-          mountPath: /host/usr/bin
+        - name: localbin
+          mountPath: /host/usr/local/bin
       containers:
       - name: ovs-cni-plugin
         image: ${OVS_CNI_PLUGIN_IMAGE_REPO}/${OVS_CNI_PLUGIN_IMAGE_NAME}:${OVS_CNI_PLUGIN_IMAGE_VERSION}
@@ -82,9 +82,9 @@ spec:
               fieldRef:
                 fieldPath: spec.nodeName
       volumes:
-        - name: usrbin
+        - name: localbin
           hostPath:
-            path: /usr/bin
+            path: /usr/local/bin
         - name: cnibin
           hostPath:
             path: /opt/cni/bin


### PR DESCRIPTION
On some platforms, for example, CoreOS, /usr/bin/ is not available for
writing, so an attempt to copy files there fails with 'read only file
system' error. Even if the file system would be mounted as read-write,
it's still a bad idea to touch it because this may potentially break
ovs-vsctl tool that may already be installed on the host.

Insted of writing and overriding files in /usr/bin/, copy them to
/opt/cni/bin that should be available for writing for all CNI plugin
pods.