### PR TITLE
ovs version to 2.10

### DIFF
--- a/cmd/marker/Dockerfile
+++ b/cmd/marker/Dockerfile
@@ -1,5 +1,5 @@
-FROM centos:centos7
-RUN yum install -y openvswitch && yum clean all
+FROM fedora:29
+RUN dnf install -y openvswitch && dnf clean all
 COPY marker /marker
 COPY .version /.version
 ENTRYPOINT [ "./marker", "-v", "3", "-logtostderr"]

--- a/cmd/plugin/Dockerfile
+++ b/cmd/plugin/Dockerfile
@@ -1,4 +1,5 @@
-FROM centos:centos7
+FROM fedora:29
+RUN dnf install -y openvswitch && dnf clean all
 COPY plugin /ovs
 COPY .version /.version
 CMD ["sh", "-c", "cp /ovs /host/opt/cni/bin/ovs && sleep infinity"]


### PR DESCRIPTION
This PR change the base image to fedora 29 to have ovs  version 2.10

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubevirt/ovs-cni/75)
<!-- Reviewable:end -->
