### PR TITLE
use static binding for build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ build: format $(patsubst %, build-%, $(COMPONENTS))
 
 build-%:
 	hack/version.sh > ./cmd/$(subst -,/,$*)/.version
-	cd cmd/$(subst -,/,$*) && go fmt && go vet && go build
+	cd cmd/$(subst -,/,$*) && go fmt && go vet && GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -tags no_openssl
 
 format:
 	go fmt ./pkg/...


### PR DESCRIPTION
In order to avoid issues with loading of libunbound.so.2 use
static binding.