### PR TITLE
use Go 1.12 on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 sudo: required
 dist: trusty
-go: "1.10"
+go: "1.12"
 
 services:
 - docker

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ build: format $(patsubst %, build-%, $(COMPONENTS))
 
 build-%:
 	hack/version.sh > ./cmd/$(subst -,/,$*)/.version
-	cd cmd/$(subst -,/,$*) && go fmt && go vet && GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -tags no_openssl
+	cd cmd/$(subst -,/,$*) && go fmt && go vet && GOOS=linux GOARCH=amd64 CGO_ENABLED=0 GO111MODULE=on go build -tags no_openssl -mod vendor
 
 format:
 	go fmt ./pkg/... ./cmd/...


### PR DESCRIPTION
We also need to add -mod vendor when building binaries so Go respects
the vendor/ directory.

Signed-off-by: Petr Horacek <phoracek@redhat.com>