### PR TITLE
Upgrade DaemonSet to apps/v1

### DIFF
--- a/examples/ovs-cni.yml
+++ b/examples/ovs-cni.yml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: ovs-cni-amd64
@@ -7,6 +7,9 @@ metadata:
     tier: node
     app: ovs-cni
 spec:
+  selector:
+    matchLabels:
+      app: ovs-cni
   template:
     metadata:
       labels:

--- a/manifests/ovs-cni.yml.in
+++ b/manifests/ovs-cni.yml.in
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: ovs-cni-amd64
@@ -7,6 +7,9 @@ metadata:
     tier: node
     app: ovs-cni
 spec:
+  selector:
+    matchLabels:
+      app: ovs-cni
   template:
     metadata:
       labels:


### PR DESCRIPTION
K8s v1.16 has removed deprecated versions of `DaemonSet` (both `extensions/v1beta1` and `apps/v1beta2`), we should probably update the example accordingly.

FYI, `apps/v1/DaemonSet` is available since v1.9, thus this patch would narrow the supported K8s version range to v1.9 and above, if that's not already the case before.

Ref: https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/