### PR TITLE
Add support for trunk with selective vlans

### DIFF
--- a/pkg/ovsdb/ovsdb.go
+++ b/pkg/ovsdb/ovsdb.go
@@ -97,13 +97,13 @@ func (self *OvsDriver) ovsdbTransact(ops []libovsdb.Operation) ([]libovsdb.Opera
 
 // **************** OVS driver API ********************
 // Create an internal port in OVS
-func (self *OvsBridgeDriver) CreatePort(intfName, contNetnsPath, contIfaceName, ovnPortName string, vlanTags []uint, portType string) error {
+func (self *OvsBridgeDriver) CreatePort(intfName, contNetnsPath, contIfaceName, ovnPortName string, vlanTag uint, trunks []uint, portType string) error {
 	intfUuid, intfOp, err := createInterfaceOperation(intfName, ovnPortName)
 	if err != nil {
 		return err
 	}
 
-	portUuid, portOp, err := createPortOperation(intfName, contNetnsPath, contIfaceName, vlanTags, portType, intfUuid)
+	portUuid, portOp, err := createPortOperation(intfName, contNetnsPath, contIfaceName, vlanTag, trunks, portType, intfUuid)
 	if err != nil {
 		return err
 	}
@@ -295,7 +295,7 @@ func createInterfaceOperation(intfName, ovnPortName string) ([]libovsdb.UUID, *l
 	return intfUuid, &intfOp, nil
 }
 
-func createPortOperation(intfName, contNetnsPath, contIfaceName string, vlanTags []uint, portType string, intfUuid []libovsdb.UUID) ([]libovsdb.UUID, *libovsdb.Operation, error) {
+func createPortOperation(intfName, contNetnsPath, contIfaceName string, vlanTag uint, trunks []uint, portType string, intfUuid []libovsdb.UUID) ([]libovsdb.UUID, *libovsdb.Operation, error) {
 	portUuidStr := intfName
 	portUuid := []libovsdb.UUID{{GoUUID: portUuidStr}}
 
@@ -305,9 +305,9 @@ func createPortOperation(intfName, contNetnsPath, contIfaceName string, vlanTags
 	port["vlan_mode"] = portType
 	var err error
 	if portType == "access" {
-		port["tag"] = vlanTags[0]
-	} else if len(vlanTags) > 0 {
-		port["trunks"], err = libovsdb.NewOvsSet(vlanTags)
+		port["tag"] = vlanTag
+	} else if len(trunks) > 0 {
+		port["trunks"], err = libovsdb.NewOvsSet(trunks)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/pkg/ovsdb/ovsdb.go
+++ b/pkg/ovsdb/ovsdb.go
@@ -97,13 +97,13 @@ func (self *OvsDriver) ovsdbTransact(ops []libovsdb.Operation) ([]libovsdb.Opera
 
 // **************** OVS driver API ********************
 // Create an internal port in OVS
-func (self *OvsBridgeDriver) CreatePort(intfName, contNetnsPath, contIfaceName, ovnPortName string, vlanTag uint) error {
+func (self *OvsBridgeDriver) CreatePort(intfName, contNetnsPath, contIfaceName, ovnPortName string, vlanTags []uint, portType string) error {
 	intfUuid, intfOp, err := createInterfaceOperation(intfName, ovnPortName)
 	if err != nil {
 		return err
 	}
 
-	portUuid, portOp, err := createPortOperation(intfName, contNetnsPath, contIfaceName, vlanTag, intfUuid)
+	portUuid, portOp, err := createPortOperation(intfName, contNetnsPath, contIfaceName, vlanTags, portType, intfUuid)
 	if err != nil {
 		return err
 	}
@@ -295,20 +295,24 @@ func createInterfaceOperation(intfName, ovnPortName string) ([]libovsdb.UUID, *l
 	return intfUuid, &intfOp, nil
 }
 
-func createPortOperation(intfName, contNetnsPath, contIfaceName string, vlanTag uint, intfUuid []libovsdb.UUID) ([]libovsdb.UUID, *libovsdb.Operation, error) {
+func createPortOperation(intfName, contNetnsPath, contIfaceName string, vlanTags []uint, portType string, intfUuid []libovsdb.UUID) ([]libovsdb.UUID, *libovsdb.Operation, error) {
 	portUuidStr := intfName
 	portUuid := []libovsdb.UUID{{GoUUID: portUuidStr}}
 
 	port := make(map[string]interface{})
 	port["name"] = intfName
-	if vlanTag != 0 {
-		port["vlan_mode"] = "access"
-		port["tag"] = vlanTag
-	} else {
-		port["vlan_mode"] = "trunk"
+
+	port["vlan_mode"] = portType
+	var err error
+	if portType == "access" {
+		port["tag"] = vlanTags[0]
+	} else if len(vlanTags) > 0 {
+		port["trunks"], err = libovsdb.NewOvsSet(vlanTags)
+		if err != nil {
+			return nil, nil, err
+		}
 	}
 
-	var err error
 	port["interfaces"], err = libovsdb.NewOvsSet(intfUuid)
 	if err != nil {
 		return nil, nil, err

--- a/pkg/plugin/plugin_test.go
+++ b/pkg/plugin/plugin_test.go
@@ -15,6 +15,8 @@
 package plugin
 
 import (
+	"encoding/json"
+	"errors"
 	"fmt"
 	"net"
 	"os/exec"
@@ -63,6 +65,26 @@ var _ = Describe("CNI Plugin", func() {
 		output, err := exec.Command("ovs-vsctl", "del-br", BRIDGE_NAME).CombinedOutput()
 		Expect(err).NotTo(HaveOccurred(), "Failed to remove testing OVS bridge: %v", string(output[:]))
 	})
+
+	testSplitVlanIds := func(conf string, expTrunks []uint, expErr error, setUnmarshalErr bool) {
+		var trunks []*trunk
+		err := json.Unmarshal([]byte(conf), &trunks)
+		if setUnmarshalErr {
+			Expect(err).To(HaveOccurred())
+			return
+		} else {
+			Expect(err).NotTo(HaveOccurred())
+		}
+		By("Calling splitVlanIds method")
+		vlanIds, err := splitVlanIds(trunks)
+		if expErr != nil {
+			By("Checking expected error is occurred")
+			Expect(err).To(Equal(expErr))
+		} else {
+			By("Checking vlanIds are same as trunk vlans")
+			Expect(vlanIds).To(Equal(expTrunks))
+		}
+	}
 
 	testAddDel := func(conf string, setVlan, setMtu bool, Trunk string) {
 		const IFNAME = "eth0"
@@ -220,7 +242,7 @@ var _ = Describe("CNI Plugin", func() {
 				testAddDel(conf, false, false, "")
 			})
 		})
-		Context("with specific VLAN ID ranges set on port", func() {
+		Context("with specific VLAN ID ranges set (via both range and id) for the port", func() {
 			conf := fmt.Sprintf(`{
 				"cniVersion": "0.3.1",
 				"name": "mynet",
@@ -321,6 +343,42 @@ var _ = Describe("CNI Plugin", func() {
 				output, err := exec.Command("ovs-vsctl", "--colum=external_ids", "find", "Interface", fmt.Sprintf("name=%s", hostIface.Name)).CombinedOutput()
 				Expect(err).NotTo(HaveOccurred())
 				Expect(string(output[:len(output)-1])).To(Equal(ovsOutput))
+			})
+		})
+		Context("specify trunk with multiple ranges", func() {
+			trunks := `[ {"minID": 10, "maxID": 12}, {"minID": 19, "maxID": 20} ]`
+			It("testSplitVlanIds method should return with specifed values in the range", func() {
+				testSplitVlanIds(trunks, []uint{10, 11, 12, 19, 20}, nil, false)
+			})
+		})
+		Context("specify trunk with multiple ids", func() {
+			trunks := `[ {"id": 15}, {"id": 19}, {"id": 40} ]`
+			It("testSplitVlanIds method should return with specifed id values", func() {
+				testSplitVlanIds(trunks, []uint{15, 19, 40}, nil, false)
+			})
+		})
+		Context("specify trunk with minID/maxID same value and duplicate values", func() {
+			trunks := `[ {"minID": 10, "maxID": 14}, {"id": 11}, {"minID": 13, "maxID": 13} ]`
+			It("testSplitVlanIds method should return without duplicate trunk values", func() {
+				testSplitVlanIds(trunks, []uint{10, 11, 12, 13, 14}, nil, false)
+			})
+		})
+		Context("specify trunk with negative value", func() {
+			trunks := `[ {"id": 15}, {"id": 15}, {"id": -20} ]`
+			It("testSplitVlanIds method should throw appropriate error", func() {
+				testSplitVlanIds(trunks, nil, errors.New("incorrect trunk id parameter"), true)
+			})
+		})
+		Context("specify trunk with minID greater than maxID", func() {
+			trunks := `[ {"minID": 10, "maxID": 12}, {"minID": 11, "maxID": 5} ]`
+			It("testSplitVlanIds method should throw appropriate error", func() {
+				testSplitVlanIds(trunks, nil, errors.New("minID is greater than maxID in trunk parameter"), false)
+			})
+		})
+		Context("specify trunk with maxID greater than 4096", func() {
+			trunks := `[ {"minID": 10, "maxID": 12}, {"minID": 1, "maxID": 5000} ]`
+			It("testSplitVlanIds method should throw appropriate error", func() {
+				testSplitVlanIds(trunks, nil, errors.New("incorrect trunk maxID parameter"), false)
 			})
 		})
 	})


### PR DESCRIPTION
This patch adds the feature to support selective vlan ids to be specified for trunk port via new parameter (`trunk`) in net-attach-definition.

Signed-off-by: Periyasamy Palanisamy <periyasamy.palanisamy@est.tech>