### PR TITLE
Add IPAM support

### DIFF
--- a/vendor/github.com/containernetworking/cni/pkg/invoke/args.go
+++ b/vendor/github.com/containernetworking/cni/pkg/invoke/args.go
@@ -1,0 +1,128 @@
+// Copyright 2015 CNI authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package invoke
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+type CNIArgs interface {
+	// For use with os/exec; i.e., return nil to inherit the
+	// environment from this process
+	// For use in delegation; inherit the environment from this
+	// process and allow overrides
+	AsEnv() []string
+}
+
+type inherited struct{}
+
+var inheritArgsFromEnv inherited
+
+func (_ *inherited) AsEnv() []string {
+	return nil
+}
+
+func ArgsFromEnv() CNIArgs {
+	return &inheritArgsFromEnv
+}
+
+type Args struct {
+	Command       string
+	ContainerID   string
+	NetNS         string
+	PluginArgs    [][2]string
+	PluginArgsStr string
+	IfName        string
+	Path          string
+}
+
+// Args implements the CNIArgs interface
+var _ CNIArgs = &Args{}
+
+func (args *Args) AsEnv() []string {
+	env := os.Environ()
+	pluginArgsStr := args.PluginArgsStr
+	if pluginArgsStr == "" {
+		pluginArgsStr = stringify(args.PluginArgs)
+	}
+
+	// Duplicated values which come first will be overrided, so we must put the
+	// custom values in the end to avoid being overrided by the process environments.
+	env = append(env,
+		"CNI_COMMAND="+args.Command,
+		"CNI_CONTAINERID="+args.ContainerID,
+		"CNI_NETNS="+args.NetNS,
+		"CNI_ARGS="+pluginArgsStr,
+		"CNI_IFNAME="+args.IfName,
+		"CNI_PATH="+args.Path,
+	)
+	return dedupEnv(env)
+}
+
+// taken from rkt/networking/net_plugin.go
+func stringify(pluginArgs [][2]string) string {
+	entries := make([]string, len(pluginArgs))
+
+	for i, kv := range pluginArgs {
+		entries[i] = strings.Join(kv[:], "=")
+	}
+
+	return strings.Join(entries, ";")
+}
+
+// DelegateArgs implements the CNIArgs interface
+// used for delegation to inherit from environments
+// and allow some overrides like CNI_COMMAND
+var _ CNIArgs = &DelegateArgs{}
+
+type DelegateArgs struct {
+	Command string
+}
+
+func (d *DelegateArgs) AsEnv() []string {
+	env := os.Environ()
+
+	// The custom values should come in the end to override the existing
+	// process environment of the same key.
+	env = append(env,
+		"CNI_COMMAND="+d.Command,
+	)
+	return dedupEnv(env)
+}
+
+// dedupEnv returns a copy of env with any duplicates removed, in favor of later values.
+// Items not of the normal environment "key=value" form are preserved unchanged.
+func dedupEnv(env []string) []string {
+	out := make([]string, 0, len(env))
+	envMap := map[string]string{}
+
+	for _, kv := range env {
+		// find the first "=" in environment, if not, just keep it
+		eq := strings.Index(kv, "=")
+		if eq < 0 {
+			out = append(out, kv)
+			continue
+		}
+		envMap[kv[:eq]] = kv[eq+1:]
+	}
+
+	for k, v := range envMap {
+		out = append(out, fmt.Sprintf("%s=%s", k, v))
+	}
+
+	return out
+}

--- a/vendor/github.com/containernetworking/cni/pkg/invoke/args_test.go
+++ b/vendor/github.com/containernetworking/cni/pkg/invoke/args_test.go
@@ -1,0 +1,139 @@
+// Copyright 2017 CNI authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package invoke_test
+
+import (
+	"os"
+
+	"github.com/containernetworking/cni/pkg/invoke"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("CNIArgs AsEnv", func() {
+	Describe("Args AsEnv", func() {
+		BeforeEach(func() {
+			os.Setenv("CNI_COMMAND", "DEL")
+			os.Setenv("CNI_IFNAME", "eth0")
+			os.Setenv("CNI_CONTAINERID", "id")
+			os.Setenv("CNI_ARGS", "args")
+			os.Setenv("CNI_NETNS", "testns")
+			os.Setenv("CNI_PATH", "testpath")
+		})
+
+		It("places the CNI environment variables in the end to be prepended", func() {
+			args := invoke.Args{
+				Command:     "ADD",
+				ContainerID: "some-container-id",
+				NetNS:       "/some/netns/path",
+				PluginArgs: [][2]string{
+					{"KEY1", "VALUE1"},
+					{"KEY2", "VALUE2"},
+				},
+				IfName: "eth7",
+				Path:   "/some/cni/path",
+			}
+
+			latentEnvs := os.Environ()
+			numLatentEnvs := len(latentEnvs)
+
+			cniEnvs := args.AsEnv()
+			Expect(len(cniEnvs)).To(Equal(numLatentEnvs))
+
+			Expect(inStringSlice("CNI_COMMAND=ADD", cniEnvs)).To(Equal(true))
+			Expect(inStringSlice("CNI_IFNAME=eth7", cniEnvs)).To(Equal(true))
+			Expect(inStringSlice("CNI_CONTAINERID=some-container-id", cniEnvs)).To(Equal(true))
+			Expect(inStringSlice("CNI_NETNS=/some/netns/path", cniEnvs)).To(Equal(true))
+			Expect(inStringSlice("CNI_ARGS=KEY1=VALUE1;KEY2=VALUE2", cniEnvs)).To(Equal(true))
+			Expect(inStringSlice("CNI_PATH=/some/cni/path", cniEnvs)).To(Equal(true))
+
+			Expect(inStringSlice("CNI_COMMAND=DEL", cniEnvs)).To(Equal(false))
+			Expect(inStringSlice("CNI_IFNAME=eth0", cniEnvs)).To(Equal(false))
+			Expect(inStringSlice("CNI_CONTAINERID=id", cniEnvs)).To(Equal(false))
+			Expect(inStringSlice("CNI_NETNS=testns", cniEnvs)).To(Equal(false))
+			Expect(inStringSlice("CNI_ARGS=args", cniEnvs)).To(Equal(false))
+			Expect(inStringSlice("CNI_PATH=testpath", cniEnvs)).To(Equal(false))
+		})
+
+		AfterEach(func() {
+			os.Unsetenv("CNI_COMMAND")
+			os.Unsetenv("CNI_IFNAME")
+			os.Unsetenv("CNI_CONTAINERID")
+			os.Unsetenv("CNI_ARGS")
+			os.Unsetenv("CNI_NETNS")
+			os.Unsetenv("CNI_PATH")
+		})
+	})
+
+	Describe("DelegateArgs AsEnv", func() {
+		BeforeEach(func() {
+			os.Unsetenv("CNI_COMMAND")
+		})
+
+		It("override CNI_COMMAND if it already exists in environment variables", func() {
+			os.Setenv("CNI_COMMAND", "DEL")
+
+			delegateArgs := invoke.DelegateArgs{
+				Command: "ADD",
+			}
+
+			latentEnvs := os.Environ()
+			numLatentEnvs := len(latentEnvs)
+
+			cniEnvs := delegateArgs.AsEnv()
+			Expect(len(cniEnvs)).To(Equal(numLatentEnvs))
+
+			Expect(inStringSlice("CNI_COMMAND=ADD", cniEnvs)).To(Equal(true))
+			Expect(inStringSlice("CNI_COMMAND=DEL", cniEnvs)).To(Equal(false))
+		})
+
+		It("append CNI_COMMAND if it does not exist in environment variables", func() {
+			delegateArgs := invoke.DelegateArgs{
+				Command: "ADD",
+			}
+
+			latentEnvs := os.Environ()
+			numLatentEnvs := len(latentEnvs)
+
+			cniEnvs := delegateArgs.AsEnv()
+			Expect(len(cniEnvs)).To(Equal(numLatentEnvs + 1))
+
+			Expect(inStringSlice("CNI_COMMAND=ADD", cniEnvs)).To(Equal(true))
+		})
+
+		AfterEach(func() {
+			os.Unsetenv("CNI_COMMAND")
+		})
+	})
+
+	Describe("inherited AsEnv", func() {
+		It("return nil string slice if we call AsEnv of inherited", func() {
+			inheritedArgs := invoke.ArgsFromEnv()
+
+			var nilSlice []string = nil
+			Expect(inheritedArgs.AsEnv()).To(Equal(nilSlice))
+		})
+	})
+})
+
+func inStringSlice(in string, slice []string) bool {
+	for _, s := range slice {
+		if in == s {
+			return true
+		}
+	}
+	return false
+}

--- a/vendor/github.com/containernetworking/cni/pkg/invoke/delegate.go
+++ b/vendor/github.com/containernetworking/cni/pkg/invoke/delegate.go
@@ -1,0 +1,80 @@
+// Copyright 2016 CNI authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package invoke
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+
+	"github.com/containernetworking/cni/pkg/types"
+)
+
+func delegateCommon(delegatePlugin string, exec Exec) (string, Exec, error) {
+	if exec == nil {
+		exec = defaultExec
+	}
+
+	paths := filepath.SplitList(os.Getenv("CNI_PATH"))
+	pluginPath, err := exec.FindInPath(delegatePlugin, paths)
+	if err != nil {
+		return "", nil, err
+	}
+
+	return pluginPath, exec, nil
+}
+
+// DelegateAdd calls the given delegate plugin with the CNI ADD action and
+// JSON configuration
+func DelegateAdd(ctx context.Context, delegatePlugin string, netconf []byte, exec Exec) (types.Result, error) {
+	pluginPath, realExec, err := delegateCommon(delegatePlugin, exec)
+	if err != nil {
+		return nil, err
+	}
+
+	// DelegateAdd will override the original "CNI_COMMAND" env from process with ADD
+	return ExecPluginWithResult(ctx, pluginPath, netconf, delegateArgs("ADD"), realExec)
+}
+
+// DelegateCheck calls the given delegate plugin with the CNI CHECK action and
+// JSON configuration
+func DelegateCheck(ctx context.Context, delegatePlugin string, netconf []byte, exec Exec) error {
+	pluginPath, realExec, err := delegateCommon(delegatePlugin, exec)
+	if err != nil {
+		return err
+	}
+
+	// DelegateCheck will override the original CNI_COMMAND env from process with CHECK
+	return ExecPluginWithoutResult(ctx, pluginPath, netconf, delegateArgs("CHECK"), realExec)
+}
+
+// DelegateDel calls the given delegate plugin with the CNI DEL action and
+// JSON configuration
+func DelegateDel(ctx context.Context, delegatePlugin string, netconf []byte, exec Exec) error {
+	pluginPath, realExec, err := delegateCommon(delegatePlugin, exec)
+	if err != nil {
+		return err
+	}
+
+	// DelegateDel will override the original CNI_COMMAND env from process with DEL
+	return ExecPluginWithoutResult(ctx, pluginPath, netconf, delegateArgs("DEL"), realExec)
+}
+
+// return CNIArgs used by delegation
+func delegateArgs(action string) *DelegateArgs {
+	return &DelegateArgs{
+		Command: action,
+	}
+}

--- a/vendor/github.com/containernetworking/cni/pkg/invoke/delegate_test.go
+++ b/vendor/github.com/containernetworking/cni/pkg/invoke/delegate_test.go
@@ -1,0 +1,227 @@
+// Copyright 2017 CNI authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package invoke_test
+
+import (
+	"context"
+	"encoding/json"
+	"io/ioutil"
+	"net"
+	"os"
+	"path/filepath"
+
+	"github.com/containernetworking/cni/pkg/invoke"
+	"github.com/containernetworking/cni/pkg/types/current"
+	"github.com/containernetworking/cni/plugins/test/noop/debug"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Delegate", func() {
+	var (
+		pluginName     string
+		netConf        []byte
+		debugFileName  string
+		debugBehavior  *debug.Debug
+		expectedResult *current.Result
+		ctx            context.Context
+	)
+
+	BeforeEach(func() {
+		netConf, _ = json.Marshal(map[string]string{
+			"name":       "delegate-test",
+			"cniVersion": "0.4.0",
+		})
+
+		expectedResult = &current.Result{
+			CNIVersion: "0.4.0",
+			IPs: []*current.IPConfig{
+				{
+					Version: "4",
+					Address: net.IPNet{
+						IP:   net.ParseIP("10.1.2.3"),
+						Mask: net.CIDRMask(24, 32),
+					},
+				},
+			},
+		}
+		expectedResultBytes, _ := json.Marshal(expectedResult)
+
+		debugFile, err := ioutil.TempFile("", "cni_debug")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(debugFile.Close()).To(Succeed())
+		debugFileName = debugFile.Name()
+		debugBehavior = &debug.Debug{
+			ReportResult: string(expectedResultBytes),
+		}
+		Expect(debugBehavior.WriteDebug(debugFileName)).To(Succeed())
+		pluginName = "noop"
+		ctx = context.TODO()
+		os.Setenv("CNI_ARGS", "DEBUG="+debugFileName)
+		os.Setenv("CNI_PATH", filepath.Dir(pathToPlugin))
+		os.Setenv("CNI_NETNS", "/tmp/some/netns/path")
+		os.Setenv("CNI_IFNAME", "eth7")
+		os.Setenv("CNI_CONTAINERID", "container")
+	})
+
+	AfterEach(func() {
+		os.RemoveAll(debugFileName)
+
+		for _, k := range []string{"CNI_COMMAND", "CNI_ARGS", "CNI_PATH", "CNI_NETNS", "CNI_IFNAME"} {
+			os.Unsetenv(k)
+		}
+	})
+
+	Describe("DelegateAdd", func() {
+		BeforeEach(func() {
+			os.Setenv("CNI_COMMAND", "ADD")
+		})
+
+		It("finds and execs the named plugin", func() {
+			result, err := invoke.DelegateAdd(ctx, pluginName, netConf, nil)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal(expectedResult))
+
+			pluginInvocation, err := debug.ReadDebug(debugFileName)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(pluginInvocation.Command).To(Equal("ADD"))
+			Expect(pluginInvocation.CmdArgs.IfName).To(Equal("eth7"))
+		})
+
+		Context("if the ADD delegation runs on an existing non-ADD command, ", func() {
+			BeforeEach(func() {
+				os.Setenv("CNI_COMMAND", "NOPE")
+			})
+
+			It("aborts and returns a useful error", func() {
+				result, err := invoke.DelegateAdd(ctx, pluginName, netConf, nil)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).To(Equal(expectedResult))
+
+				pluginInvocation, err := debug.ReadDebug(debugFileName)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(pluginInvocation.Command).To(Equal("ADD"))
+				Expect(pluginInvocation.CmdArgs.IfName).To(Equal("eth7"))
+
+				// check the original env
+				Expect(os.Getenv("CNI_COMMAND")).To(Equal("NOPE"))
+			})
+		})
+
+		Context("when the plugin cannot be found", func() {
+			BeforeEach(func() {
+				pluginName = "non-existent-plugin"
+			})
+
+			It("returns a useful error", func() {
+				_, err := invoke.DelegateAdd(ctx, pluginName, netConf, nil)
+				Expect(err).To(MatchError(HavePrefix("failed to find plugin")))
+			})
+		})
+	})
+
+	Describe("DelegateCheck", func() {
+		BeforeEach(func() {
+			os.Setenv("CNI_COMMAND", "CHECK")
+		})
+
+		It("finds and execs the named plugin", func() {
+			err := invoke.DelegateCheck(ctx, pluginName, netConf, nil)
+			Expect(err).NotTo(HaveOccurred())
+
+			pluginInvocation, err := debug.ReadDebug(debugFileName)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(pluginInvocation.Command).To(Equal("CHECK"))
+			Expect(pluginInvocation.CmdArgs.IfName).To(Equal("eth7"))
+		})
+
+		Context("if the CHECK delegation runs on an existing non-CHECK command", func() {
+			BeforeEach(func() {
+				os.Setenv("CNI_COMMAND", "NOPE")
+			})
+
+			It("aborts and returns a useful error", func() {
+				err := invoke.DelegateCheck(ctx, pluginName, netConf, nil)
+				Expect(err).NotTo(HaveOccurred())
+
+				pluginInvocation, err := debug.ReadDebug(debugFileName)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(pluginInvocation.Command).To(Equal("CHECK"))
+				Expect(pluginInvocation.CmdArgs.IfName).To(Equal("eth7"))
+
+				// check the original env
+				Expect(os.Getenv("CNI_COMMAND")).To(Equal("NOPE"))
+			})
+		})
+
+		Context("when the plugin cannot be found", func() {
+			BeforeEach(func() {
+				pluginName = "non-existent-plugin"
+			})
+
+			It("returns a useful error", func() {
+				err := invoke.DelegateCheck(ctx, pluginName, netConf, nil)
+				Expect(err).To(MatchError(HavePrefix("failed to find plugin")))
+			})
+		})
+	})
+
+	Describe("DelegateDel", func() {
+		BeforeEach(func() {
+			os.Setenv("CNI_COMMAND", "DEL")
+		})
+
+		It("finds and execs the named plugin", func() {
+			err := invoke.DelegateDel(ctx, pluginName, netConf, nil)
+			Expect(err).NotTo(HaveOccurred())
+
+			pluginInvocation, err := debug.ReadDebug(debugFileName)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(pluginInvocation.Command).To(Equal("DEL"))
+			Expect(pluginInvocation.CmdArgs.IfName).To(Equal("eth7"))
+		})
+
+		Context("if the DEL delegation runs on an existing non-DEL command", func() {
+			BeforeEach(func() {
+				os.Setenv("CNI_COMMAND", "NOPE")
+			})
+
+			It("aborts and returns a useful error", func() {
+				err := invoke.DelegateDel(ctx, pluginName, netConf, nil)
+				Expect(err).NotTo(HaveOccurred())
+
+				pluginInvocation, err := debug.ReadDebug(debugFileName)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(pluginInvocation.Command).To(Equal("DEL"))
+				Expect(pluginInvocation.CmdArgs.IfName).To(Equal("eth7"))
+
+				// check the original env
+				Expect(os.Getenv("CNI_COMMAND")).To(Equal("NOPE"))
+			})
+		})
+
+		Context("when the plugin cannot be found", func() {
+			BeforeEach(func() {
+				pluginName = "non-existent-plugin"
+			})
+
+			It("returns a useful error", func() {
+				err := invoke.DelegateDel(ctx, pluginName, netConf, nil)
+				Expect(err).To(MatchError(HavePrefix("failed to find plugin")))
+			})
+		})
+	})
+})

--- a/vendor/github.com/containernetworking/cni/pkg/invoke/exec.go
+++ b/vendor/github.com/containernetworking/cni/pkg/invoke/exec.go
@@ -1,0 +1,144 @@
+// Copyright 2015 CNI authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package invoke
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/containernetworking/cni/pkg/types"
+	"github.com/containernetworking/cni/pkg/version"
+)
+
+// Exec is an interface encapsulates all operations that deal with finding
+// and executing a CNI plugin. Tests may provide a fake implementation
+// to avoid writing fake plugins to temporary directories during the test.
+type Exec interface {
+	ExecPlugin(ctx context.Context, pluginPath string, stdinData []byte, environ []string) ([]byte, error)
+	FindInPath(plugin string, paths []string) (string, error)
+	Decode(jsonBytes []byte) (version.PluginInfo, error)
+}
+
+// For example, a testcase could pass an instance of the following fakeExec
+// object to ExecPluginWithResult() to verify the incoming stdin and environment
+// and provide a tailored response:
+//
+//import (
+//	"encoding/json"
+//	"path"
+//	"strings"
+//)
+//
+//type fakeExec struct {
+//	version.PluginDecoder
+//}
+//
+//func (f *fakeExec) ExecPlugin(pluginPath string, stdinData []byte, environ []string) ([]byte, error) {
+//	net := &types.NetConf{}
+//	err := json.Unmarshal(stdinData, net)
+//	if err != nil {
+//		return nil, fmt.Errorf("failed to unmarshal configuration: %v", err)
+//	}
+//	pluginName := path.Base(pluginPath)
+//	if pluginName != net.Type {
+//		return nil, fmt.Errorf("plugin name %q did not match config type %q", pluginName, net.Type)
+//	}
+//	for _, e := range environ {
+//		// Check environment for forced failure request
+//		parts := strings.Split(e, "=")
+//		if len(parts) > 0 && parts[0] == "FAIL" {
+//			return nil, fmt.Errorf("failed to execute plugin %s", pluginName)
+//		}
+//	}
+//	return []byte("{\"CNIVersion\":\"0.4.0\"}"), nil
+//}
+//
+//func (f *fakeExec) FindInPath(plugin string, paths []string) (string, error) {
+//	if len(paths) > 0 {
+//		return path.Join(paths[0], plugin), nil
+//	}
+//	return "", fmt.Errorf("failed to find plugin %s in paths %v", plugin, paths)
+//}
+
+func ExecPluginWithResult(ctx context.Context, pluginPath string, netconf []byte, args CNIArgs, exec Exec) (types.Result, error) {
+	if exec == nil {
+		exec = defaultExec
+	}
+
+	stdoutBytes, err := exec.ExecPlugin(ctx, pluginPath, netconf, args.AsEnv())
+	if err != nil {
+		return nil, err
+	}
+
+	// Plugin must return result in same version as specified in netconf
+	versionDecoder := &version.ConfigDecoder{}
+	confVersion, err := versionDecoder.Decode(netconf)
+	if err != nil {
+		return nil, err
+	}
+
+	return version.NewResult(confVersion, stdoutBytes)
+}
+
+func ExecPluginWithoutResult(ctx context.Context, pluginPath string, netconf []byte, args CNIArgs, exec Exec) error {
+	if exec == nil {
+		exec = defaultExec
+	}
+	_, err := exec.ExecPlugin(ctx, pluginPath, netconf, args.AsEnv())
+	return err
+}
+
+// GetVersionInfo returns the version information available about the plugin.
+// For recent-enough plugins, it uses the information returned by the VERSION
+// command.  For older plugins which do not recognize that command, it reports
+// version 0.1.0
+func GetVersionInfo(ctx context.Context, pluginPath string, exec Exec) (version.PluginInfo, error) {
+	if exec == nil {
+		exec = defaultExec
+	}
+	args := &Args{
+		Command: "VERSION",
+
+		// set fake values required by plugins built against an older version of skel
+		NetNS:  "dummy",
+		IfName: "dummy",
+		Path:   "dummy",
+	}
+	stdin := []byte(fmt.Sprintf(`{"cniVersion":%q}`, version.Current()))
+	stdoutBytes, err := exec.ExecPlugin(ctx, pluginPath, stdin, args.AsEnv())
+	if err != nil {
+		if err.Error() == "unknown CNI_COMMAND: VERSION" {
+			return version.PluginSupports("0.1.0"), nil
+		}
+		return nil, err
+	}
+
+	return exec.Decode(stdoutBytes)
+}
+
+// DefaultExec is an object that implements the Exec interface which looks
+// for and executes plugins from disk.
+type DefaultExec struct {
+	*RawExec
+	version.PluginDecoder
+}
+
+// DefaultExec implements the Exec interface
+var _ Exec = &DefaultExec{}
+
+var defaultExec = &DefaultExec{
+	RawExec: &RawExec{Stderr: os.Stderr},
+}

--- a/vendor/github.com/containernetworking/cni/pkg/invoke/exec_test.go
+++ b/vendor/github.com/containernetworking/cni/pkg/invoke/exec_test.go
@@ -1,0 +1,179 @@
+// Copyright 2016 CNI authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package invoke_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+
+	"github.com/containernetworking/cni/pkg/invoke"
+	"github.com/containernetworking/cni/pkg/invoke/fakes"
+	"github.com/containernetworking/cni/pkg/types/current"
+	"github.com/containernetworking/cni/pkg/version"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Executing a plugin, unit tests", func() {
+	var (
+		pluginExec     invoke.Exec
+		rawExec        *fakes.RawExec
+		versionDecoder *fakes.VersionDecoder
+
+		pluginPath string
+		netconf    []byte
+		cniargs    *fakes.CNIArgs
+		ctx        context.Context
+	)
+
+	BeforeEach(func() {
+		rawExec = &fakes.RawExec{}
+		rawExec.ExecPluginCall.Returns.ResultBytes = []byte(`{ "ips": [ { "version": "4", "address": "1.2.3.4/24" } ] }`)
+
+		versionDecoder = &fakes.VersionDecoder{}
+		versionDecoder.DecodeCall.Returns.PluginInfo = version.PluginSupports("0.42.0")
+
+		pluginExec = &struct {
+			*fakes.RawExec
+			*fakes.VersionDecoder
+		}{
+			RawExec:        rawExec,
+			VersionDecoder: versionDecoder,
+		}
+		pluginPath = "/some/plugin/path"
+		netconf = []byte(`{ "some": "stdin", "cniVersion": "0.3.1" }`)
+		cniargs = &fakes.CNIArgs{}
+		cniargs.AsEnvCall.Returns.Env = []string{"SOME=ENV"}
+		ctx = context.TODO()
+	})
+
+	Describe("returning a result", func() {
+		It("unmarshals the result bytes into the Result type", func() {
+			r, err := invoke.ExecPluginWithResult(ctx, pluginPath, netconf, cniargs, pluginExec)
+			Expect(err).NotTo(HaveOccurred())
+
+			result, err := current.GetResult(r)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(len(result.IPs)).To(Equal(1))
+			Expect(result.IPs[0].Address.IP.String()).To(Equal("1.2.3.4"))
+		})
+
+		It("passes its arguments through to the rawExec", func() {
+			invoke.ExecPluginWithResult(ctx, pluginPath, netconf, cniargs, pluginExec)
+			Expect(rawExec.ExecPluginCall.Received.PluginPath).To(Equal(pluginPath))
+			Expect(rawExec.ExecPluginCall.Received.StdinData).To(Equal(netconf))
+			Expect(rawExec.ExecPluginCall.Received.Environ).To(Equal([]string{"SOME=ENV"}))
+		})
+
+		Context("when the rawExec fails", func() {
+			BeforeEach(func() {
+				rawExec.ExecPluginCall.Returns.Error = errors.New("banana")
+			})
+			It("returns the error", func() {
+				_, err := invoke.ExecPluginWithResult(ctx, pluginPath, netconf, cniargs, pluginExec)
+				Expect(err).To(MatchError("banana"))
+			})
+		})
+
+		It("returns an error using the default exec interface", func() {
+			// pluginPath should not exist on-disk so we expect an error.
+			// This test simply tests that the default exec handler
+			// is run when the exec interface is nil.
+			_, err := invoke.ExecPluginWithResult(ctx, pluginPath, netconf, cniargs, nil)
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	Describe("without returning a result", func() {
+		It("passes its arguments through to the rawExec", func() {
+			invoke.ExecPluginWithoutResult(ctx, pluginPath, netconf, cniargs, pluginExec)
+			Expect(rawExec.ExecPluginCall.Received.PluginPath).To(Equal(pluginPath))
+			Expect(rawExec.ExecPluginCall.Received.StdinData).To(Equal(netconf))
+			Expect(rawExec.ExecPluginCall.Received.Environ).To(Equal([]string{"SOME=ENV"}))
+		})
+
+		Context("when the rawExec fails", func() {
+			BeforeEach(func() {
+				rawExec.ExecPluginCall.Returns.Error = errors.New("banana")
+			})
+			It("returns the error", func() {
+				err := invoke.ExecPluginWithoutResult(ctx, pluginPath, netconf, cniargs, pluginExec)
+				Expect(err).To(MatchError("banana"))
+			})
+		})
+
+		It("returns an error using the default exec interface", func() {
+			// pluginPath should not exist on-disk so we expect an error.
+			// This test simply tests that the default exec handler
+			// is run when the exec interface is nil.
+			err := invoke.ExecPluginWithoutResult(ctx, pluginPath, netconf, cniargs, nil)
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	Describe("discovering the plugin version", func() {
+		BeforeEach(func() {
+			rawExec.ExecPluginCall.Returns.ResultBytes = []byte(`{ "some": "version-info" }`)
+		})
+
+		It("execs the plugin with the command VERSION", func() {
+			invoke.GetVersionInfo(ctx, pluginPath, pluginExec)
+			Expect(rawExec.ExecPluginCall.Received.PluginPath).To(Equal(pluginPath))
+			Expect(rawExec.ExecPluginCall.Received.Environ).To(ContainElement("CNI_COMMAND=VERSION"))
+			expectedStdin, _ := json.Marshal(map[string]string{"cniVersion": version.Current()})
+			Expect(rawExec.ExecPluginCall.Received.StdinData).To(MatchJSON(expectedStdin))
+		})
+
+		It("decodes and returns the version info", func() {
+			versionInfo, err := invoke.GetVersionInfo(ctx, pluginPath, pluginExec)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(versionInfo.SupportedVersions()).To(Equal([]string{"0.42.0"}))
+			Expect(versionDecoder.DecodeCall.Received.JSONBytes).To(MatchJSON(`{ "some": "version-info" }`))
+		})
+
+		Context("when the rawExec fails", func() {
+			BeforeEach(func() {
+				rawExec.ExecPluginCall.Returns.Error = errors.New("banana")
+			})
+			It("returns the error", func() {
+				_, err := invoke.GetVersionInfo(ctx, pluginPath, pluginExec)
+				Expect(err).To(MatchError("banana"))
+			})
+		})
+
+		Context("when the plugin is too old to recognize the VERSION command", func() {
+			BeforeEach(func() {
+				rawExec.ExecPluginCall.Returns.Error = errors.New("unknown CNI_COMMAND: VERSION")
+			})
+
+			It("interprets the error as a 0.1.0 version", func() {
+				versionInfo, err := invoke.GetVersionInfo(ctx, pluginPath, pluginExec)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(versionInfo.SupportedVersions()).To(ConsistOf("0.1.0"))
+			})
+
+			It("sets dummy values for env vars required by very old plugins", func() {
+				invoke.GetVersionInfo(ctx, pluginPath, pluginExec)
+
+				env := rawExec.ExecPluginCall.Received.Environ
+				Expect(env).To(ContainElement("CNI_NETNS=dummy"))
+				Expect(env).To(ContainElement("CNI_IFNAME=dummy"))
+				Expect(env).To(ContainElement("CNI_PATH=dummy"))
+			})
+		})
+	})
+})

--- a/vendor/github.com/containernetworking/cni/pkg/invoke/fakes/cni_args.go
+++ b/vendor/github.com/containernetworking/cni/pkg/invoke/fakes/cni_args.go
@@ -1,0 +1,27 @@
+// Copyright 2016 CNI authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fakes
+
+type CNIArgs struct {
+	AsEnvCall struct {
+		Returns struct {
+			Env []string
+		}
+	}
+}
+
+func (a *CNIArgs) AsEnv() []string {
+	return a.AsEnvCall.Returns.Env
+}

--- a/vendor/github.com/containernetworking/cni/pkg/invoke/fakes/raw_exec.go
+++ b/vendor/github.com/containernetworking/cni/pkg/invoke/fakes/raw_exec.go
@@ -1,0 +1,54 @@
+// Copyright 2016 CNI authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fakes
+
+import "context"
+
+type RawExec struct {
+	ExecPluginCall struct {
+		Received struct {
+			PluginPath string
+			StdinData  []byte
+			Environ    []string
+		}
+		Returns struct {
+			ResultBytes []byte
+			Error       error
+		}
+	}
+	FindInPathCall struct {
+		Received struct {
+			Plugin string
+			Paths  []string
+		}
+		Returns struct {
+			Path  string
+			Error error
+		}
+	}
+}
+
+func (e *RawExec) ExecPlugin(ctx context.Context, pluginPath string, stdinData []byte, environ []string) ([]byte, error) {
+	e.ExecPluginCall.Received.PluginPath = pluginPath
+	e.ExecPluginCall.Received.StdinData = stdinData
+	e.ExecPluginCall.Received.Environ = environ
+	return e.ExecPluginCall.Returns.ResultBytes, e.ExecPluginCall.Returns.Error
+}
+
+func (e *RawExec) FindInPath(plugin string, paths []string) (string, error) {
+	e.FindInPathCall.Received.Plugin = plugin
+	e.FindInPathCall.Received.Paths = paths
+	return e.FindInPathCall.Returns.Path, e.FindInPathCall.Returns.Error
+}

--- a/vendor/github.com/containernetworking/cni/pkg/invoke/fakes/version_decoder.go
+++ b/vendor/github.com/containernetworking/cni/pkg/invoke/fakes/version_decoder.go
@@ -1,0 +1,34 @@
+// Copyright 2016 CNI authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fakes
+
+import "github.com/containernetworking/cni/pkg/version"
+
+type VersionDecoder struct {
+	DecodeCall struct {
+		Received struct {
+			JSONBytes []byte
+		}
+		Returns struct {
+			PluginInfo version.PluginInfo
+			Error      error
+		}
+	}
+}
+
+func (e *VersionDecoder) Decode(jsonData []byte) (version.PluginInfo, error) {
+	e.DecodeCall.Received.JSONBytes = jsonData
+	return e.DecodeCall.Returns.PluginInfo, e.DecodeCall.Returns.Error
+}

--- a/vendor/github.com/containernetworking/cni/pkg/invoke/find.go
+++ b/vendor/github.com/containernetworking/cni/pkg/invoke/find.go
@@ -1,0 +1,43 @@
+// Copyright 2015 CNI authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package invoke
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// FindInPath returns the full path of the plugin by searching in the provided path
+func FindInPath(plugin string, paths []string) (string, error) {
+	if plugin == "" {
+		return "", fmt.Errorf("no plugin name provided")
+	}
+
+	if len(paths) == 0 {
+		return "", fmt.Errorf("no paths provided")
+	}
+
+	for _, path := range paths {
+		for _, fe := range ExecutableFileExtensions {
+			fullpath := filepath.Join(path, plugin) + fe
+			if fi, err := os.Stat(fullpath); err == nil && fi.Mode().IsRegular() {
+				return fullpath, nil
+			}
+		}
+	}
+
+	return "", fmt.Errorf("failed to find plugin %q in path %s", plugin, paths)
+}

--- a/vendor/github.com/containernetworking/cni/pkg/invoke/find_test.go
+++ b/vendor/github.com/containernetworking/cni/pkg/invoke/find_test.go
@@ -1,0 +1,103 @@
+// Copyright 2016 CNI authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package invoke_test
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/containernetworking/cni/pkg/invoke"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("FindInPath", func() {
+	var (
+		multiplePaths         []string
+		pluginName            string
+		plugin2NameWithExt    string
+		plugin2NameWithoutExt string
+		pluginDir             string
+		anotherTempDir        string
+	)
+
+	BeforeEach(func() {
+		tempDir, err := ioutil.TempDir("", "cni-find")
+		Expect(err).NotTo(HaveOccurred())
+
+		plugin, err := ioutil.TempFile(tempDir, "a-cni-plugin")
+		Expect(err).NotTo(HaveOccurred())
+
+		plugin2Name := "a-plugin-with-extension" + invoke.ExecutableFileExtensions[0]
+		plugin2, err := os.Create(filepath.Join(tempDir, plugin2Name))
+		Expect(err).NotTo(HaveOccurred())
+
+		anotherTempDir, err = ioutil.TempDir("", "nothing-here")
+		Expect(err).NotTo(HaveOccurred())
+
+		multiplePaths = []string{anotherTempDir, tempDir}
+		pluginDir, pluginName = filepath.Split(plugin.Name())
+		_, plugin2NameWithExt = filepath.Split(plugin2.Name())
+		plugin2NameWithoutExt = strings.Split(plugin2NameWithExt, ".")[0]
+	})
+
+	AfterEach(func() {
+		os.RemoveAll(pluginDir)
+		os.RemoveAll(anotherTempDir)
+	})
+
+	Context("when multiple paths are provided", func() {
+		It("returns only the path to the plugin", func() {
+			pluginPath, err := invoke.FindInPath(pluginName, multiplePaths)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(pluginPath).To(Equal(filepath.Join(pluginDir, pluginName)))
+		})
+	})
+
+	Context("when a plugin name without its file name extension is provided", func() {
+		It("returns the path to the plugin, including its extension", func() {
+			pluginPath, err := invoke.FindInPath(plugin2NameWithoutExt, multiplePaths)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(pluginPath).To(Equal(filepath.Join(pluginDir, plugin2NameWithExt)))
+		})
+	})
+
+	Context("when an error occurs", func() {
+		Context("when no paths are provided", func() {
+			It("returns an error noting no paths were provided", func() {
+				_, err := invoke.FindInPath(pluginName, []string{})
+				Expect(err).To(MatchError("no paths provided"))
+			})
+		})
+
+		Context("when no plugin is provided", func() {
+			It("returns an error noting the plugin name wasn't found", func() {
+				_, err := invoke.FindInPath("", multiplePaths)
+				Expect(err).To(MatchError("no plugin name provided"))
+			})
+		})
+
+		Context("when the plugin cannot be found", func() {
+			It("returns an error noting the path", func() {
+				pathsWithNothing := []string{anotherTempDir}
+				_, err := invoke.FindInPath(pluginName, pathsWithNothing)
+				Expect(err).To(MatchError(fmt.Sprintf("failed to find plugin %q in path %s", pluginName, pathsWithNothing)))
+			})
+		})
+	})
+})

--- a/vendor/github.com/containernetworking/cni/pkg/invoke/get_version_integration_test.go
+++ b/vendor/github.com/containernetworking/cni/pkg/invoke/get_version_integration_test.go
@@ -1,0 +1,133 @@
+// Copyright 2016 CNI authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package invoke_test
+
+import (
+	"context"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"runtime"
+
+	"github.com/containernetworking/cni/pkg/invoke"
+	"github.com/containernetworking/cni/pkg/version"
+	"github.com/containernetworking/cni/pkg/version/testhelpers"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("GetVersion, integration tests", func() {
+	var (
+		pluginDir  string
+		pluginPath string
+	)
+
+	BeforeEach(func() {
+		pluginDir, err := ioutil.TempDir("", "plugins")
+		Expect(err).NotTo(HaveOccurred())
+		pluginPath = filepath.Join(pluginDir, "test-plugin")
+		if runtime.GOOS == "windows" {
+			pluginPath += ".exe"
+		}
+	})
+
+	AfterEach(func() {
+		Expect(os.RemoveAll(pluginDir)).To(Succeed())
+	})
+
+	DescribeTable("correctly reporting plugin versions",
+		func(gitRef string, pluginSource string, expectedVersions version.PluginInfo) {
+			Expect(testhelpers.BuildAt([]byte(pluginSource), gitRef, pluginPath)).To(Succeed())
+			versionInfo, err := invoke.GetVersionInfo(context.TODO(), pluginPath, nil)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(versionInfo.SupportedVersions()).To(ConsistOf(expectedVersions.SupportedVersions()))
+		},
+
+		Entry("historical: before VERSION was introduced",
+			git_ref_v010, plugin_source_no_custom_versions,
+			version.PluginSupports("0.1.0"),
+		),
+
+		Entry("historical: when VERSION was introduced but plugins couldn't customize it",
+			git_ref_v020_no_custom_versions, plugin_source_no_custom_versions,
+			version.PluginSupports("0.1.0", "0.2.0"),
+		),
+
+		Entry("historical: when plugins started reporting their own version list",
+			git_ref_v020_custom_versions, plugin_source_v020_custom_versions,
+			version.PluginSupports("0.2.0", "0.999.0"),
+		),
+
+		Entry("historical: before CHECK was introduced",
+			git_ref_v031, plugin_source_v020_custom_versions,
+			version.PluginSupports("0.2.0", "0.999.0"),
+		),
+
+		// this entry tracks the current behavior.  Before you change it, ensure
+		// that its previous behavior is captured in the most recent "historical" entry
+		Entry("current",
+			"HEAD", plugin_source_v040_check,
+			version.PluginSupports("0.2.0", "0.4.0", "0.999.0"),
+		),
+	)
+})
+
+// A 0.4.0 plugin that supports CHECK
+const plugin_source_v040_check = `package main
+
+import (
+	"github.com/containernetworking/cni/pkg/skel"
+	"github.com/containernetworking/cni/pkg/version"
+	"fmt"
+)
+
+func c(_ *skel.CmdArgs) error { fmt.Println("{}"); return nil }
+
+func main() { skel.PluginMain(c, c, c, version.PluginSupports("0.2.0", "0.4.0", "0.999.0"), "") }
+`
+
+const git_ref_v031 = "909fe7d"
+
+// a 0.2.0 plugin that can report its own versions
+const plugin_source_v020_custom_versions = `package main
+
+import (
+	"github.com/containernetworking/cni/pkg/skel"
+	"github.com/containernetworking/cni/pkg/version"
+	"fmt"
+)
+
+func c(_ *skel.CmdArgs) error { fmt.Println("{}"); return nil }
+
+func main() { skel.PluginMain(c, c, version.PluginSupports("0.2.0", "0.999.0")) }
+`
+const git_ref_v020_custom_versions = "bf31ed15"
+
+// a minimal 0.1.0 / 0.2.0 plugin that cannot report it's own version support
+const plugin_source_no_custom_versions = `package main
+
+import "github.com/containernetworking/cni/pkg/skel"
+import "fmt"
+
+func c(_ *skel.CmdArgs) error { fmt.Println("{}"); return nil }
+
+func main() { skel.PluginMain(c, c) }
+`
+
+const git_ref_v010 = "2c482f4"
+const git_ref_v020_no_custom_versions = "349d66d"

--- a/vendor/github.com/containernetworking/cni/pkg/invoke/invoke_suite_test.go
+++ b/vendor/github.com/containernetworking/cni/pkg/invoke/invoke_suite_test.go
@@ -1,0 +1,45 @@
+// Copyright 2016 CNI authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package invoke_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gexec"
+
+	"testing"
+)
+
+func TestInvoke(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Invoke Suite")
+}
+
+const packagePath = "github.com/containernetworking/cni/plugins/test/noop"
+
+var pathToPlugin string
+
+var _ = SynchronizedBeforeSuite(func() []byte {
+	var err error
+	pathToPlugin, err = gexec.Build(packagePath)
+	Expect(err).NotTo(HaveOccurred())
+	return []byte(pathToPlugin)
+}, func(crossNodeData []byte) {
+	pathToPlugin = string(crossNodeData)
+})
+
+var _ = SynchronizedAfterSuite(func() {}, func() {
+	gexec.CleanupBuildArtifacts()
+})

--- a/vendor/github.com/containernetworking/cni/pkg/invoke/os_unix.go
+++ b/vendor/github.com/containernetworking/cni/pkg/invoke/os_unix.go
@@ -1,0 +1,20 @@
+// Copyright 2016 CNI authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build darwin dragonfly freebsd linux netbsd openbsd solaris
+
+package invoke
+
+// Valid file extensions for plugin executables.
+var ExecutableFileExtensions = []string{""}

--- a/vendor/github.com/containernetworking/cni/pkg/invoke/os_windows.go
+++ b/vendor/github.com/containernetworking/cni/pkg/invoke/os_windows.go
@@ -1,0 +1,18 @@
+// Copyright 2016 CNI authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package invoke
+
+// Valid file extensions for plugin executables.
+var ExecutableFileExtensions = []string{".exe", ""}

--- a/vendor/github.com/containernetworking/cni/pkg/invoke/raw_exec.go
+++ b/vendor/github.com/containernetworking/cni/pkg/invoke/raw_exec.go
@@ -1,0 +1,62 @@
+// Copyright 2016 CNI authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package invoke
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os/exec"
+
+	"github.com/containernetworking/cni/pkg/types"
+)
+
+type RawExec struct {
+	Stderr io.Writer
+}
+
+func (e *RawExec) ExecPlugin(ctx context.Context, pluginPath string, stdinData []byte, environ []string) ([]byte, error) {
+	stdout := &bytes.Buffer{}
+	c := exec.CommandContext(ctx, pluginPath)
+	c.Env = environ
+	c.Stdin = bytes.NewBuffer(stdinData)
+	c.Stdout = stdout
+	c.Stderr = e.Stderr
+	if err := c.Run(); err != nil {
+		return nil, pluginErr(err, stdout.Bytes())
+	}
+
+	return stdout.Bytes(), nil
+}
+
+func pluginErr(err error, output []byte) error {
+	if _, ok := err.(*exec.ExitError); ok {
+		emsg := types.Error{}
+		if len(output) == 0 {
+			emsg.Msg = "netplugin failed with no error message"
+		} else if perr := json.Unmarshal(output, &emsg); perr != nil {
+			emsg.Msg = fmt.Sprintf("netplugin failed but error parsing its diagnostic message %q: %v", string(output), perr)
+		}
+		return &emsg
+	}
+
+	return err
+}
+
+func (e *RawExec) FindInPath(plugin string, paths []string) (string, error) {
+	return FindInPath(plugin, paths)
+}

--- a/vendor/github.com/containernetworking/cni/pkg/invoke/raw_exec_test.go
+++ b/vendor/github.com/containernetworking/cni/pkg/invoke/raw_exec_test.go
@@ -1,0 +1,126 @@
+// Copyright 2016 CNI authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package invoke_test
+
+import (
+	"bytes"
+	"context"
+	"io/ioutil"
+	"os"
+
+	"github.com/containernetworking/cni/pkg/invoke"
+
+	noop_debug "github.com/containernetworking/cni/plugins/test/noop/debug"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("RawExec", func() {
+	var (
+		debugFileName string
+		debug         *noop_debug.Debug
+		environ       []string
+		stdin         []byte
+		execer        *invoke.RawExec
+		ctx           context.Context
+	)
+
+	const reportResult = `{ "some": "result" }`
+
+	BeforeEach(func() {
+		debugFile, err := ioutil.TempFile("", "cni_debug")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(debugFile.Close()).To(Succeed())
+		debugFileName = debugFile.Name()
+
+		debug = &noop_debug.Debug{
+			ReportResult: reportResult,
+			ReportStderr: "some stderr message",
+		}
+		Expect(debug.WriteDebug(debugFileName)).To(Succeed())
+
+		environ = []string{
+			"CNI_COMMAND=ADD",
+			"CNI_CONTAINERID=some-container-id",
+			"CNI_ARGS=DEBUG=" + debugFileName,
+			"CNI_NETNS=/some/netns/path",
+			"CNI_PATH=/some/bin/path",
+			"CNI_IFNAME=some-eth0",
+		}
+		stdin = []byte(`{"name": "raw-exec-test", "some":"stdin-json", "cniVersion": "0.3.1"}`)
+		execer = &invoke.RawExec{}
+		ctx = context.TODO()
+	})
+
+	AfterEach(func() {
+		Expect(os.Remove(debugFileName)).To(Succeed())
+	})
+
+	It("runs the plugin with the given stdin and environment", func() {
+		_, err := execer.ExecPlugin(ctx, pathToPlugin, stdin, environ)
+		Expect(err).NotTo(HaveOccurred())
+
+		debug, err := noop_debug.ReadDebug(debugFileName)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(debug.Command).To(Equal("ADD"))
+		Expect(debug.CmdArgs.StdinData).To(Equal(stdin))
+		Expect(debug.CmdArgs.Netns).To(Equal("/some/netns/path"))
+	})
+
+	It("returns the resulting stdout as bytes", func() {
+		resultBytes, err := execer.ExecPlugin(ctx, pathToPlugin, stdin, environ)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(resultBytes).To(BeEquivalentTo(reportResult))
+	})
+
+	Context("when the Stderr writer is set", func() {
+		var stderrBuffer *bytes.Buffer
+
+		BeforeEach(func() {
+			stderrBuffer = &bytes.Buffer{}
+			execer.Stderr = stderrBuffer
+		})
+
+		It("forwards any stderr bytes to the Stderr writer", func() {
+			_, err := execer.ExecPlugin(ctx, pathToPlugin, stdin, environ)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(stderrBuffer.String()).To(Equal("some stderr message"))
+		})
+	})
+
+	Context("when the plugin errors", func() {
+		BeforeEach(func() {
+			debug.ReportError = "banana"
+			Expect(debug.WriteDebug(debugFileName)).To(Succeed())
+		})
+
+		It("wraps and returns the error", func() {
+			_, err := execer.ExecPlugin(ctx, pathToPlugin, stdin, environ)
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError("banana"))
+		})
+	})
+
+	Context("when the system is unable to execute the plugin", func() {
+		It("returns the error", func() {
+			_, err := execer.ExecPlugin(ctx, "/tmp/some/invalid/plugin/path", stdin, environ)
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError(ContainSubstring("/tmp/some/invalid/plugin/path")))
+		})
+	})
+})

--- a/vendor/github.com/containernetworking/plugins/pkg/ipam/ipam.go
+++ b/vendor/github.com/containernetworking/plugins/pkg/ipam/ipam.go
@@ -1,0 +1,33 @@
+// Copyright 2015 CNI authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ipam
+
+import (
+	"context"
+	"github.com/containernetworking/cni/pkg/invoke"
+	"github.com/containernetworking/cni/pkg/types"
+)
+
+func ExecAdd(plugin string, netconf []byte) (types.Result, error) {
+	return invoke.DelegateAdd(context.TODO(), plugin, netconf, nil)
+}
+
+func ExecCheck(plugin string, netconf []byte) error {
+	return invoke.DelegateCheck(context.TODO(), plugin, netconf, nil)
+}
+
+func ExecDel(plugin string, netconf []byte) error {
+	return invoke.DelegateDel(context.TODO(), plugin, netconf, nil)
+}

--- a/vendor/github.com/containernetworking/plugins/pkg/ipam/ipam_linux.go
+++ b/vendor/github.com/containernetworking/plugins/pkg/ipam/ipam_linux.go
@@ -1,0 +1,121 @@
+// Copyright 2015 CNI authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ipam
+
+import (
+	"fmt"
+	"net"
+	"os"
+
+	"github.com/containernetworking/cni/pkg/types/current"
+	"github.com/containernetworking/plugins/pkg/ip"
+	"github.com/containernetworking/plugins/pkg/utils/sysctl"
+
+	"github.com/vishvananda/netlink"
+)
+
+const (
+	DisableIPv6SysctlTemplate = "net.ipv6.conf.%s.disable_ipv6"
+)
+
+// ConfigureIface takes the result of IPAM plugin and
+// applies to the ifName interface
+func ConfigureIface(ifName string, res *current.Result) error {
+	if len(res.Interfaces) == 0 {
+		return fmt.Errorf("no interfaces to configure")
+	}
+
+	link, err := netlink.LinkByName(ifName)
+	if err != nil {
+		return fmt.Errorf("failed to lookup %q: %v", ifName, err)
+	}
+
+	if err := netlink.LinkSetUp(link); err != nil {
+		return fmt.Errorf("failed to set %q UP: %v", ifName, err)
+	}
+
+	var v4gw, v6gw net.IP
+	var has_enabled_ipv6 bool = false
+	for _, ipc := range res.IPs {
+		if ipc.Interface == nil {
+			continue
+		}
+		intIdx := *ipc.Interface
+		if intIdx < 0 || intIdx >= len(res.Interfaces) || res.Interfaces[intIdx].Name != ifName {
+			// IP address is for a different interface
+			return fmt.Errorf("failed to add IP addr %v to %q: invalid interface index", ipc, ifName)
+		}
+
+		// Make sure sysctl "disable_ipv6" is 0 if we are about to add
+		// an IPv6 address to the interface
+		if !has_enabled_ipv6 && ipc.Version == "6" {
+			// Enabled IPv6 for loopback "lo" and the interface
+			// being configured
+			for _, iface := range [2]string{"lo", ifName} {
+				ipv6SysctlValueName := fmt.Sprintf(DisableIPv6SysctlTemplate, iface)
+
+				// Read current sysctl value
+				value, err := sysctl.Sysctl(ipv6SysctlValueName)
+				if err != nil || value == "0" {
+					// FIXME: log warning if unable to read sysctl value
+					continue
+				}
+
+				// Write sysctl to enable IPv6
+				_, err = sysctl.Sysctl(ipv6SysctlValueName, "0")
+				if err != nil {
+					return fmt.Errorf("failed to enable IPv6 for interface %q (%s=%s): %v", iface, ipv6SysctlValueName, value, err)
+				}
+			}
+			has_enabled_ipv6 = true
+		}
+
+		addr := &netlink.Addr{IPNet: &ipc.Address, Label: ""}
+		if err = netlink.AddrAdd(link, addr); err != nil {
+			return fmt.Errorf("failed to add IP addr %v to %q: %v", ipc, ifName, err)
+		}
+
+		gwIsV4 := ipc.Gateway.To4() != nil
+		if gwIsV4 && v4gw == nil {
+			v4gw = ipc.Gateway
+		} else if !gwIsV4 && v6gw == nil {
+			v6gw = ipc.Gateway
+		}
+	}
+
+	if v6gw != nil {
+		ip.SettleAddresses(ifName, 10)
+	}
+
+	for _, r := range res.Routes {
+		routeIsV4 := r.Dst.IP.To4() != nil
+		gw := r.GW
+		if gw == nil {
+			if routeIsV4 && v4gw != nil {
+				gw = v4gw
+			} else if !routeIsV4 && v6gw != nil {
+				gw = v6gw
+			}
+		}
+		if err = ip.AddRoute(&r.Dst, gw, link); err != nil {
+			// we skip over duplicate routes as we assume the first one wins
+			if !os.IsExist(err) {
+				return fmt.Errorf("failed to add route '%v via %v dev %v': %v", r.Dst, gw, ifName, err)
+			}
+		}
+	}
+
+	return nil
+}

--- a/vendor/github.com/containernetworking/plugins/pkg/ipam/ipam_linux_test.go
+++ b/vendor/github.com/containernetworking/plugins/pkg/ipam/ipam_linux_test.go
@@ -1,0 +1,300 @@
+// Copyright 2015 CNI authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ipam
+
+import (
+	"net"
+	"syscall"
+
+	"github.com/containernetworking/cni/pkg/types"
+	"github.com/containernetworking/cni/pkg/types/current"
+	"github.com/containernetworking/plugins/pkg/ns"
+	"github.com/containernetworking/plugins/pkg/testutils"
+
+	"github.com/vishvananda/netlink"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+const LINK_NAME = "eth0"
+
+func ipNetEqual(a, b *net.IPNet) bool {
+	aPrefix, aBits := a.Mask.Size()
+	bPrefix, bBits := b.Mask.Size()
+	if aPrefix != bPrefix || aBits != bBits {
+		return false
+	}
+	return a.IP.Equal(b.IP)
+}
+
+var _ = Describe("ConfigureIface", func() {
+	var originalNS ns.NetNS
+	var ipv4, ipv6, routev4, routev6 *net.IPNet
+	var ipgw4, ipgw6, routegwv4, routegwv6 net.IP
+	var result *current.Result
+
+	BeforeEach(func() {
+		// Create a new NetNS so we don't modify the host
+		var err error
+		originalNS, err = testutils.NewNS()
+		Expect(err).NotTo(HaveOccurred())
+
+		err = originalNS.Do(func(ns.NetNS) error {
+			defer GinkgoRecover()
+
+			// Add master
+			err = netlink.LinkAdd(&netlink.Dummy{
+				LinkAttrs: netlink.LinkAttrs{
+					Name: LINK_NAME,
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+			_, err = netlink.LinkByName(LINK_NAME)
+			Expect(err).NotTo(HaveOccurred())
+			return nil
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		ipv4, err = types.ParseCIDR("1.2.3.30/24")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(ipv4).NotTo(BeNil())
+
+		_, routev4, err = net.ParseCIDR("15.5.6.8/24")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(routev4).NotTo(BeNil())
+		routegwv4 = net.ParseIP("1.2.3.5")
+		Expect(routegwv4).NotTo(BeNil())
+
+		ipgw4 = net.ParseIP("1.2.3.1")
+		Expect(ipgw4).NotTo(BeNil())
+
+		ipv6, err = types.ParseCIDR("abcd:1234:ffff::cdde/64")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(ipv6).NotTo(BeNil())
+
+		_, routev6, err = net.ParseCIDR("1111:dddd::aaaa/80")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(routev6).NotTo(BeNil())
+		routegwv6 = net.ParseIP("abcd:1234:ffff::10")
+		Expect(routegwv6).NotTo(BeNil())
+
+		ipgw6 = net.ParseIP("abcd:1234:ffff::1")
+		Expect(ipgw6).NotTo(BeNil())
+
+		result = &current.Result{
+			Interfaces: []*current.Interface{
+				{
+					Name:    "eth0",
+					Mac:     "00:11:22:33:44:55",
+					Sandbox: "/proc/3553/ns/net",
+				},
+				{
+					Name:    "fake0",
+					Mac:     "00:33:44:55:66:77",
+					Sandbox: "/proc/1234/ns/net",
+				},
+			},
+			IPs: []*current.IPConfig{
+				{
+					Version:   "4",
+					Interface: current.Int(0),
+					Address:   *ipv4,
+					Gateway:   ipgw4,
+				},
+				{
+					Version:   "6",
+					Interface: current.Int(0),
+					Address:   *ipv6,
+					Gateway:   ipgw6,
+				},
+			},
+			Routes: []*types.Route{
+				{Dst: *routev4, GW: routegwv4},
+				{Dst: *routev6, GW: routegwv6},
+			},
+		}
+	})
+
+	AfterEach(func() {
+		Expect(originalNS.Close()).To(Succeed())
+	})
+
+	It("configures a link with addresses and routes", func() {
+		err := originalNS.Do(func(ns.NetNS) error {
+			defer GinkgoRecover()
+
+			err := ConfigureIface(LINK_NAME, result)
+			Expect(err).NotTo(HaveOccurred())
+
+			link, err := netlink.LinkByName(LINK_NAME)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(link.Attrs().Name).To(Equal(LINK_NAME))
+
+			v4addrs, err := netlink.AddrList(link, syscall.AF_INET)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(len(v4addrs)).To(Equal(1))
+			Expect(ipNetEqual(v4addrs[0].IPNet, ipv4)).To(Equal(true))
+
+			v6addrs, err := netlink.AddrList(link, syscall.AF_INET6)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(len(v6addrs)).To(Equal(2))
+
+			var found bool
+			for _, a := range v6addrs {
+				if ipNetEqual(a.IPNet, ipv6) {
+					found = true
+					break
+				}
+			}
+			Expect(found).To(Equal(true))
+
+			// Ensure the v4 route, v6 route, and subnet route
+			routes, err := netlink.RouteList(link, 0)
+			Expect(err).NotTo(HaveOccurred())
+
+			var v4found, v6found bool
+			for _, route := range routes {
+				isv4 := route.Dst.IP.To4() != nil
+				if isv4 && ipNetEqual(route.Dst, routev4) && route.Gw.Equal(routegwv4) {
+					v4found = true
+				}
+				if !isv4 && ipNetEqual(route.Dst, routev6) && route.Gw.Equal(routegwv6) {
+					v6found = true
+				}
+
+				if v4found && v6found {
+					break
+				}
+			}
+			Expect(v4found).To(Equal(true))
+			Expect(v6found).To(Equal(true))
+
+			return nil
+		})
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("configures a link with routes using address gateways", func() {
+		result.Routes[0].GW = nil
+		result.Routes[1].GW = nil
+		err := originalNS.Do(func(ns.NetNS) error {
+			defer GinkgoRecover()
+
+			err := ConfigureIface(LINK_NAME, result)
+			Expect(err).NotTo(HaveOccurred())
+
+			link, err := netlink.LinkByName(LINK_NAME)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(link.Attrs().Name).To(Equal(LINK_NAME))
+
+			// Ensure the v4 route, v6 route, and subnet route
+			routes, err := netlink.RouteList(link, 0)
+			Expect(err).NotTo(HaveOccurred())
+
+			var v4found, v6found bool
+			for _, route := range routes {
+				isv4 := route.Dst.IP.To4() != nil
+				if isv4 && ipNetEqual(route.Dst, routev4) && route.Gw.Equal(ipgw4) {
+					v4found = true
+				}
+				if !isv4 && ipNetEqual(route.Dst, routev6) && route.Gw.Equal(ipgw6) {
+					v6found = true
+				}
+
+				if v4found && v6found {
+					break
+				}
+			}
+			Expect(v4found).To(Equal(true))
+			Expect(v6found).To(Equal(true))
+
+			return nil
+		})
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("returns an error when the interface index doesn't match the link name", func() {
+		result.IPs[0].Interface = current.Int(1)
+		err := originalNS.Do(func(ns.NetNS) error {
+			return ConfigureIface(LINK_NAME, result)
+		})
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("returns an error when the interface index is too big", func() {
+		result.IPs[0].Interface = current.Int(2)
+		err := originalNS.Do(func(ns.NetNS) error {
+			return ConfigureIface(LINK_NAME, result)
+		})
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("returns an error when the interface index is too small", func() {
+		result.IPs[0].Interface = current.Int(-1)
+		err := originalNS.Do(func(ns.NetNS) error {
+			return ConfigureIface(LINK_NAME, result)
+		})
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("returns an error when there are no interfaces to configure", func() {
+		result.Interfaces = []*current.Interface{}
+		err := originalNS.Do(func(ns.NetNS) error {
+			return ConfigureIface(LINK_NAME, result)
+		})
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("returns an error when configuring the wrong interface", func() {
+		err := originalNS.Do(func(ns.NetNS) error {
+			return ConfigureIface("asdfasdf", result)
+		})
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("does not panic when interface is not specified", func() {
+		result = &current.Result{
+			Interfaces: []*current.Interface{
+				{
+					Name:    "eth0",
+					Mac:     "00:11:22:33:44:55",
+					Sandbox: "/proc/3553/ns/net",
+				},
+				{
+					Name:    "fake0",
+					Mac:     "00:33:44:55:66:77",
+					Sandbox: "/proc/1234/ns/net",
+				},
+			},
+			IPs: []*current.IPConfig{
+				{
+					Version: "4",
+					Address: *ipv4,
+					Gateway: ipgw4,
+				},
+				{
+					Version: "6",
+					Address: *ipv6,
+					Gateway: ipgw6,
+				},
+			},
+		}
+		err := originalNS.Do(func(ns.NetNS) error {
+			return ConfigureIface(LINK_NAME, result)
+		})
+		Expect(err).NotTo(HaveOccurred())
+	})
+})

--- a/vendor/github.com/containernetworking/plugins/pkg/ipam/ipam_suite_test.go
+++ b/vendor/github.com/containernetworking/plugins/pkg/ipam/ipam_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright 2016 CNI authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ipam_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestIpam(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "pkg/ipam")
+}

--- a/vendor/github.com/containernetworking/plugins/pkg/utils/sysctl/sysctl_linux.go
+++ b/vendor/github.com/containernetworking/plugins/pkg/utils/sysctl/sysctl_linux.go
@@ -1,0 +1,80 @@
+// Copyright 2016 CNI authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sysctl
+
+import (
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
+	"strings"
+)
+
+// Sysctl provides a method to set/get values from /proc/sys - in linux systems
+// new interface to set/get values of variables formerly handled by sysctl syscall
+// If optional `params` have only one string value - this function will
+// set this value into corresponding sysctl variable
+func Sysctl(name string, params ...string) (string, error) {
+	if len(params) > 1 {
+		return "", fmt.Errorf("unexcepted additional parameters")
+	} else if len(params) == 1 {
+		return setSysctl(name, params[0])
+	}
+	return getSysctl(name)
+}
+
+func getSysctl(name string) (string, error) {
+	fullName := filepath.Join("/proc/sys", toNormalName(name))
+	fullName = filepath.Clean(fullName)
+	data, err := ioutil.ReadFile(fullName)
+	if err != nil {
+		return "", err
+	}
+
+	return string(data[:len(data)-1]), nil
+}
+
+func setSysctl(name, value string) (string, error) {
+	fullName := filepath.Join("/proc/sys", toNormalName(name))
+	fullName = filepath.Clean(fullName)
+	if err := ioutil.WriteFile(fullName, []byte(value), 0644); err != nil {
+		return "", err
+	}
+
+	return getSysctl(name)
+}
+
+// Normalize names by using slash as separator
+// Sysctl names can use dots or slashes as separator:
+// - if dots are used, dots and slashes are interchanged.
+// - if slashes are used, slashes and dots are left intact.
+// Separator in use is determined by first occurrence.
+func toNormalName(name string) string {
+	interchange := false
+	for _, c := range name {
+		if c == '.' {
+			interchange = true
+			break
+		}
+		if c == '/' {
+			break
+		}
+	}
+
+	if interchange {
+		r := strings.NewReplacer(".", "/", "/", ".")
+		return r.Replace(name)
+	}
+	return name
+}

--- a/vendor/github.com/containernetworking/plugins/pkg/utils/sysctl/sysctl_linux_test.go
+++ b/vendor/github.com/containernetworking/plugins/pkg/utils/sysctl/sysctl_linux_test.go
@@ -1,0 +1,114 @@
+// Copyright 2017-2020 CNI authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sysctl_test
+
+import (
+	"fmt"
+	"math/rand"
+	"runtime"
+	"strings"
+
+	"github.com/containernetworking/plugins/pkg/ns"
+	"github.com/containernetworking/plugins/pkg/testutils"
+	"github.com/containernetworking/plugins/pkg/utils/sysctl"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/vishvananda/netlink"
+)
+
+const (
+	sysctlDotKeyTemplate   = "net.ipv4.conf.%s.proxy_arp"
+	sysctlSlashKeyTemplate = "net/ipv4/conf/%s/proxy_arp"
+)
+
+var _ = Describe("Sysctl tests", func() {
+	var testIfaceName string
+	var cleanup func()
+
+	BeforeEach(func() {
+
+		// Save a reference to the original namespace,
+		// Add a new NS
+		currNs, err := ns.GetCurrentNS()
+		Expect(err).NotTo(HaveOccurred())
+
+		testNs, err := testutils.NewNS()
+		Expect(err).NotTo(HaveOccurred())
+
+		testIfaceName = fmt.Sprintf("cnitest.%d", rand.Intn(100000))
+		testIface := &netlink.Dummy{
+			LinkAttrs: netlink.LinkAttrs{
+				Name:      testIfaceName,
+				Namespace: netlink.NsFd(int(testNs.Fd())),
+			},
+		}
+
+		err = netlink.LinkAdd(testIface)
+		Expect(err).NotTo(HaveOccurred())
+
+		runtime.LockOSThread()
+		err = testNs.Set()
+		Expect(err).NotTo(HaveOccurred())
+
+		cleanup = func() {
+			netlink.LinkDel(testIface)
+			currNs.Set()
+		}
+
+	})
+
+	AfterEach(func() {
+		cleanup()
+	})
+
+	Describe("Sysctl", func() {
+		It("reads keys with dot separators", func() {
+			sysctlIfaceName := strings.Replace(testIfaceName, ".", "/", -1)
+			sysctlKey := fmt.Sprintf(sysctlDotKeyTemplate, sysctlIfaceName)
+
+			_, err := sysctl.Sysctl(sysctlKey)
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	Describe("Sysctl", func() {
+		It("reads keys with slash separators", func() {
+			sysctlKey := fmt.Sprintf(sysctlSlashKeyTemplate, testIfaceName)
+
+			_, err := sysctl.Sysctl(sysctlKey)
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	Describe("Sysctl", func() {
+		It("writes keys with dot separators", func() {
+			sysctlIfaceName := strings.Replace(testIfaceName, ".", "/", -1)
+			sysctlKey := fmt.Sprintf(sysctlDotKeyTemplate, sysctlIfaceName)
+
+			_, err := sysctl.Sysctl(sysctlKey, "1")
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	Describe("Sysctl", func() {
+		It("writes keys with slash separators", func() {
+			sysctlKey := fmt.Sprintf(sysctlSlashKeyTemplate, testIfaceName)
+
+			_, err := sysctl.Sysctl(sysctlKey, "1")
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+})

--- a/vendor/github.com/containernetworking/plugins/pkg/utils/sysctl/sysctl_suite_test.go
+++ b/vendor/github.com/containernetworking/plugins/pkg/utils/sysctl/sysctl_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright 2017-2020 CNI authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sysctl_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestSysctl(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Sysctl Suite")
+}


### PR DESCRIPTION
This change would integrate an ipam module through network attachment definition for the ovs-cni.

Let me add writing unit tests in the subsequent commit once this commit is reviewed.