### PR TITLE
stdci was successfully replaced by prow

### DIFF
--- a/automation/check-patch.mounts
+++ b/automation/check-patch.mounts
@@ -1,1 +1,0 @@
-/var/run/docker.sock:/var/run/docker.sock

--- a/stdci.yaml
+++ b/stdci.yaml
@@ -1,5 +1,0 @@
-runtime_requirements:
-  support_nesting_level: 2
-  isolation_level: container
-reporting:
-  style: stdci


### PR DESCRIPTION
This patch drops stdci config files.

Signed-off-by: Petr Horacek <phoracek@redhat.com>