### PR TITLE
add test flags to make functest more readable

### DIFF
--- a/automation/check-patch.e2e.sh
+++ b/automation/check-patch.e2e.sh
@@ -25,8 +25,7 @@ main() {
     make cluster-up
     trap teardown EXIT SIGINT SIGTERM SIGSTOP
     make cluster-sync
-    ginko_params="-ginkgo.noColor --junit-output=$ARTIFACTS_PATH/tests.junit.xml"
-    FUNC_TEST_ARGS=$ginko_params make functest
+    make E2E_TEST_ARGS="-ginkgo.v -test.v -ginkgo.noColor --junit-output=$ARTIFACTS/junit.functest.xml" functest
 }
 
 [[ "${BASH_SOURCE[0]}" == "$0" ]] && main "$@"

--- a/hack/functests.sh
+++ b/hack/functests.sh
@@ -20,4 +20,4 @@ set -e
 
 source ./cluster/kubevirtci.sh
 
-go test ./tests --kubeconfig $(kubevirtci::kubeconfig) -ginkgo.v
+go test ./tests/... $E2E_TEST_ARGS --kubeconfig $(kubevirtci::kubeconfig)


### PR DESCRIPTION
Let's add test flags for better visability
We do that by -test.v verbose flag and E2E_TEST_ARGS flag to be able to disable ginkgo colors when running on prow.


Signed-off-by: Ram Lavi <ralavi@redhat.com>