### PR TITLE
add multus to cluster-up deployment

### DIFF
--- a/cluster/up.sh
+++ b/cluster/up.sh
@@ -27,3 +27,7 @@ for node in $(./cluster/kubectl.sh get nodes --no-headers | awk '{print $1}'); d
     ./cluster/cli.sh ssh ${node} -- sudo systemctl daemon-reload
     ./cluster/cli.sh ssh ${node} -- sudo systemctl restart openvswitch
 done
+
+echo 'Deploying multus'
+./cluster/kubectl.sh create -f https://raw.githubusercontent.com/intel/multus-cni/master/images/multus-daemonset.yml
+./cluster/kubectl.sh  -n kube-system wait --for=condition=ready -l name=multus pod --timeout=300s


### PR DESCRIPTION
In order to use multus-cni in tests, multus must be deployed in the cluster.
Let's add this as part of the cluster-up sequence.

Signed-off-by: Ram Lavi <ralavi@redhat.com>