### PR TITLE
Bump openvswitch to version 2.13

### DIFF
--- a/cluster/up.sh
+++ b/cluster/up.sh
@@ -23,7 +23,11 @@ $(kubevirtci::path)/cluster-up/up.sh
 
 echo 'Installing Open vSwitch on nodes'
 for node in $(./cluster/kubectl.sh get nodes --no-headers | awk '{print $1}'); do
-    ./cluster/cli.sh ssh ${node} -- sudo yum install -y http://cbs.centos.org/kojifiles/packages/openvswitch/2.9.2/1.el7/x86_64/openvswitch-2.9.2-1.el7.x86_64.rpm http://cbs.centos.org/kojifiles/packages/openvswitch/2.9.2/1.el7/x86_64/openvswitch-devel-2.9.2-1.el7.x86_64.rpm http://cbs.centos.org/kojifiles/packages/dpdk/17.11/3.el7/x86_64/dpdk-17.11-3.el7.x86_64.rpm
+    ./cluster/cli.sh ssh ${node} -- sudo yum install -y  \
+     dpdk \
+     https://cbs.centos.org/kojifiles/packages/openvswitch-selinux-extra-policy/1.0/22.el8/noarch/openvswitch-selinux-extra-policy-1.0-22.el8.noarch.rpm \
+     https://cbs.centos.org/kojifiles/packages/openvswitch2.13/2.13.0/39.el8/x86_64/openvswitch2.13-2.13.0-39.el8.x86_64.rpm \
+     https://cbs.centos.org/kojifiles/packages/openvswitch2.13/2.13.0/39.el8/x86_64/openvswitch2.13-devel-2.13.0-39.el8.x86_64.rpm
     ./cluster/cli.sh ssh ${node} -- sudo systemctl daemon-reload
     ./cluster/cli.sh ssh ${node} -- sudo systemctl restart openvswitch
 done

--- a/hack/docker-builder/Dockerfile
+++ b/hack/docker-builder/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:31
+FROM fedora:32
 
 RUN dnf -y install make git sudo gcc rsync-daemon rsync openvswitch hostname && \
     dnf -y clean all

--- a/pkg/plugin/plugin_test.go
+++ b/pkg/plugin/plugin_test.go
@@ -208,7 +208,7 @@ var _ = Describe("CNI Plugin", func() {
 		By("Checking that port external-id:contIface contains reference to container interface name")
 		externalIdContIface, err := getPortAttribute(hostIface.Name, "external-ids:contIface")
 		Expect(err).NotTo(HaveOccurred())
-		Expect(externalIdContIface).To(Equal("\"" + contIface.Name + "\""))
+		Expect(externalIdContIface).To(Equal(contIface.Name))
 
 		By("Checking that port external-id:contNetns contains reference to container namespace path")
 		externalIdContNetns, err := getPortAttribute(hostIface.Name, "external-ids:contNetns")
@@ -508,12 +508,12 @@ var _ = Describe("CNI Plugin", func() {
 				output, err = exec.Command("ovs-vsctl", "--column=name", "find", "Interface", fmt.Sprintf("name=%s", secondHostIface.Name)).CombinedOutput()
 				Expect(err).NotTo(HaveOccurred())
 				Expect(string(output)).To(
-					ContainSubstring(fmt.Sprintf("\"%s\"", secondHostIface.Name)), "Healthy OVS interface should have been kept")
+					ContainSubstring(secondHostIface.Name), "Healthy OVS interface should have been kept")
 
 				output, err = exec.Command("ovs-vsctl", "--column=name", "find", "Port", fmt.Sprintf("name=%s", secondHostIface.Name)).CombinedOutput()
 				Expect(err).NotTo(HaveOccurred())
 				Expect(string(output)).To(
-					ContainSubstring(fmt.Sprintf("\"%s\"", secondHostIface.Name)), "OVS port with healthy interface should have been kept")
+					ContainSubstring(secondHostIface.Name), "OVS port with healthy interface should have been kept")
 			})
 		})
 	})


### PR DESCRIPTION
DPDK dependency of openvswitch can now be installed directly from centos 8 extras repo.
New openvswitch version outputs interface names without doublequotes, addressing this
change in the plugin_tests.go.

Signed-off-by: Radim Hrazdil <rhrazdil@redhat.com>