### PR TITLE
handle smartnic cleanup when container net namespace is empty

### DIFF
--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -446,7 +446,7 @@ func CmdDel(args *skel.CmdArgs) error {
 			}
 			if err = removeOvsPort(ovsDriver, rep); err != nil {
 				// Don't throw err as delete can be called multiple times because of error in ResetVF and ovs
-				// port is already deleted in a previous invocation. so log it and proceed further.
+				// port is already deleted in a previous invocation.
 				log.Printf("Error: %v\n", err)
 			}
 			if err = sriov.ResetVF(args, netconf.DeviceID); err != nil {

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -437,9 +437,27 @@ func CmdDel(args *skel.CmdArgs) error {
 	if args.Netns == "" {
 		// The CNI_NETNS parameter may be empty according to version 0.4.0
 		// of the CNI spec (https://github.com/containernetworking/cni/blob/spec-v0.4.0/SPEC.md).
-		// In accordance with the spec we clean up as many resources as possible.
-		if err := cleanPorts(ovsDriver); err != nil {
-			return err
+		if netconf.DeviceID != "" {
+			// SR-IOV Case - The sriov device is moved into host network namespace when args.Netns is empty.
+			// This happens container is killed due to an error (example: CrashLoopBackOff, OOMKilled)
+			var rep string
+			if rep, err = sriov.GetNetRepresentor(netconf.DeviceID); err != nil {
+				return err
+			}
+			if err = removeOvsPort(ovsDriver, rep); err != nil {
+				// Don't throw err as delete can be called multiple times because of error in ResetVF and ovs
+				// port is already deleted in a previous invocation. so log it and proceed further.
+				log.Printf("removal of ovs port %s is failed for device %s , it may be removed already"+
+					" by previous delete call, err %v", rep, netconf.DeviceID, err)
+			}
+			if err = sriov.ResetVF(args, netconf.DeviceID); err != nil {
+				return err
+			}
+		} else {
+			// In accordance with the spec we clean up as many resources as possible.
+			if err := cleanPorts(ovsDriver); err != nil {
+				return err
+			}
 		}
 		return nil
 	} else {

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -447,8 +447,7 @@ func CmdDel(args *skel.CmdArgs) error {
 			if err = removeOvsPort(ovsDriver, rep); err != nil {
 				// Don't throw err as delete can be called multiple times because of error in ResetVF and ovs
 				// port is already deleted in a previous invocation. so log it and proceed further.
-				log.Printf("removal of ovs port %s is failed for device %s , it may be removed already"+
-					" by previous delete call, err %v", rep, netconf.DeviceID, err)
+				log.Printf("Error: %v\n", err)
 			}
 			if err = sriov.ResetVF(args, netconf.DeviceID); err != nil {
 				return err

--- a/pkg/sriov/sriov.go
+++ b/pkg/sriov/sriov.go
@@ -84,7 +84,6 @@ func GetNetRepresentor(deviceID string) (string, error) {
 	}
 
 	return rep, nil
-
 }
 
 // SetupSriovInterface moves smartVF into container namespace, rename it with ifName and also returns host interface with VF's representor device
@@ -254,7 +253,7 @@ func ResetVF(args *skel.CmdArgs, deviceID string) error {
 	// Make sure we have 1 netdevice per pci address
 	if len(vfNetdevices) != 1 {
 		// This would happen if netdevice is not yet visible in default network namespace.
-		// so return ErrLinkNotFound error so that multus can attempt multiple times
+		// so return ErrLinkNotFound error so that meta plugin can attempt multiple times
 		// until link is available.
 		return ip.ErrLinkNotFound
 	}

--- a/pkg/sriov/sriov.go
+++ b/pkg/sriov/sriov.go
@@ -25,6 +25,7 @@ import (
 	"github.com/Mellanox/sriovnet"
 	"github.com/containernetworking/cni/pkg/skel"
 	"github.com/containernetworking/cni/pkg/types/current"
+	"github.com/containernetworking/plugins/pkg/ip"
 	"github.com/containernetworking/plugins/pkg/ns"
 	"github.com/vishvananda/netlink"
 )
@@ -58,6 +59,34 @@ func getVFLinkName(pciAddr string) (string, error) {
 	return names[0], nil
 }
 
+// GetNetRepresentor retrieves network representor device for smartvf
+func GetNetRepresentor(deviceID string) (string, error) {
+	// get Uplink netdevice.  The uplink is basically the PF name of the deviceID (smart VF).
+	// The uplink is later used to retrieve the representor for the smart VF.
+	uplink, err := sriovnet.GetUplinkRepresentor(deviceID)
+	if err != nil {
+		return "", err
+	}
+
+	// get smart VF index from PCI
+	vfIndex, err := sriovnet.GetVfIndexByPciAddress(deviceID)
+	if err != nil {
+		return "", err
+	}
+
+	// get smart VF representor interface. This is a host net device which represents
+	// smart VF attached inside the container by device plugin. It can be considered
+	// as one end of veth pair whereas other end is smartVF. The VF representor would
+	// get added into ovs bridge for the control plane configuration.
+	rep, err := sriovnet.GetVfRepresentor(uplink, vfIndex)
+	if err != nil {
+		return "", err
+	}
+
+	return rep, nil
+
+}
+
 // SetupSriovInterface moves smartVF into container namespace, rename it with ifName and also returns host interface with VF's representor device
 func SetupSriovInterface(contNetns ns.NetNS, containerID, ifName string, mtu int, deviceID string) (*current.Interface, *current.Interface, error) {
 	hostIface := &current.Interface{}
@@ -84,24 +113,8 @@ func SetupSriovInterface(contNetns ns.NetNS, containerID, ifName string, mtu int
 	}
 	vfNetdevice := vfNetdevices[0]
 
-	// get Uplink netdevice.  The uplink is basically the PF name of the deviceID (smart VF).
-	// The uplink is later used to retrieve the representor for the smart VF.
-	uplink, err := sriovnet.GetUplinkRepresentor(deviceID)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	// get smart VF index from PCI
-	vfIndex, err := sriovnet.GetVfIndexByPciAddress(deviceID)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	// get smart VF representor interface. This is a host net device which represents
-	// smart VF attached inside the container by device plugin. It can be considered
-	// as one end of veth pair whereas other end is smartVF. The VF representor would
-	// get added into ovs bridge for the control plane configuration.
-	rep, err := sriovnet.GetVfRepresentor(uplink, vfIndex)
+	// network representor device for smartvf
+	rep, err := GetNetRepresentor(deviceID)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -225,4 +238,33 @@ func ReleaseVF(args *skel.CmdArgs) error {
 		return nil
 	})
 
+}
+
+// ResetVF reset the VF which accidently moved into default network namespace by a container failure
+func ResetVF(args *skel.CmdArgs, deviceID string) error {
+	hostIFName, cRefPath, err := LoadHostIFNameFromCache(args)
+	if err != nil {
+		return err
+	}
+	// get smart VF netdevice from PCI
+	vfNetdevices, err := sriovnet.GetNetDevicesFromPci(deviceID)
+	if err != nil {
+		return err
+	}
+	// Make sure we have 1 netdevice per pci address
+	if len(vfNetdevices) != 1 {
+		// This would happen if netdevice is not yet visible in default network namespace.
+		// so return ErrLinkNotFound error so that multus can attempt multiple times
+		// until link is available.
+		return ip.ErrLinkNotFound
+	}
+	_, err = renameLink(vfNetdevices[0], hostIFName)
+	if err != nil {
+		return err
+	}
+	// remove the cache entry if everything cleaned up for the device.
+	if cRefPath != "" {
+		CleanCachedConf(cRefPath)
+	}
+	return nil
 }


### PR DESCRIPTION
This change attempts to cleanup smartVFs net representor from
ovs bridge and rename smartVF back to its original name when
container network namespace is no more available due to errors
like OOMKilled, CrashLoopBackOff etc.

Signed-off-by: Periyasamy Palanisamy <periyasamy.palanisamy@est.tech>