### PR TITLE
Fix interface index in result.IPs

### DIFF
--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -367,6 +367,15 @@ func CmdAdd(args *skel.CmdArgs) error {
 		}
 		result = newResult
 		result.Interfaces = []*current.Interface{hostIface, result.Interfaces[0]}
+
+		for ifIndex, ifCfg := range result.Interfaces {
+			// Adjust interface index with new container interface index in result.Interfaces
+			if ifCfg.Name == args.IfName {
+				for ipIndex, _ := range result.IPs {
+					result.IPs[ipIndex].Interface = current.Int(ifIndex)
+				}
+			}
+		}
 	}
 
 	return types.PrintResult(result, netconf.CNIVersion)

--- a/pkg/plugin/plugin_test.go
+++ b/pkg/plugin/plugin_test.go
@@ -119,6 +119,9 @@ var _ = Describe("CNI Plugin", func() {
 
 		Expect(len(result.IPs)).To(Equal(1))
 
+		By("Checking that IP config in result of ADD command is referencing the container interface index")
+		Expect(result.IPs[0].Interface).To(Equal(current.Int(1)))
+
 		err = targetNs.Do(func(ns.NetNS) error {
 			defer GinkgoRecover()
 


### PR DESCRIPTION
Fixing GH-133. IPAM interface configuration is called with `result.Interfaces[0]` being the container interface. When IPAM configuration is finished, the `result.Interfaces` list is reordered and host interface is added at index 0 before the container interface, while `result.IPs` list of IP configuration information still points to container interface at index 0. This fixes interface index reference in IP configuration list so that chained plugins that are making use of these structures (such as sbr) will function properly.

Signed-off-by: Gabriel Dragomir <gabidrg@gmail.com>