### PR TITLE
tier1, Change KUBECONFIG to be configurable in functest

### DIFF
--- a/hack/functests.sh
+++ b/hack/functests.sh
@@ -20,4 +20,5 @@ set -e
 
 source ./cluster/kubevirtci.sh
 
-go test ./tests/... $E2E_TEST_ARGS --kubeconfig $(kubevirtci::kubeconfig)
+KUBECONFIG=${KUBECONFIG:-$(kubevirtci::kubeconfig)}
+go test ./tests/... $E2E_TEST_ARGS --kubeconfig ${KUBECONFIG}


### PR DESCRIPTION
Currently, functests only use the repo's KUBECONFIG
configuration. This means that tests will run only
on clusters generated by this repo.
Changed KUBECONFIG in hack/functest.sh to be
configurable

Signed-off-by: Ram Lavi <ralavi@redhat.com>