### PR TITLE
go-install, Add vendored go

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 cmd/marker/marker
 cmd/plugin/plugin
 
+# Temporary build files
+build/_output
+
 # used in build
 cmd/marker/.version
 cmd/plugin/.version

--- a/hack/install-go.sh
+++ b/hack/install-go.sh
@@ -1,0 +1,10 @@
+#!/bin/bash -xe
+
+destination=$1
+version=$(grep "^go " go.mod | awk '{print $2}')
+tarball=go$version.linux-amd64.tar.gz
+url=https://dl.google.com/go/
+
+mkdir -p $destination
+curl -L $url/$tarball -o $destination/$tarball
+tar -xf $destination/$tarball -C $destination


### PR DESCRIPTION
Currently tier1 tests cannot run if go
is not installed in the host. installing it
internally reduces indirections and increases
stability of code.
Added vendored go install according to version set
in go.mod

This PR fixes an [error](https://prow.apps.ovirt.org/view/gcs/kubevirt-prow/pr-logs/pull/kubevirt_project-infra/582/rehearsal-pull-e2e-cluster-network-addons-operator-ovs-cni-functests/1325733986491699200#1:build-log.txt%3A946) running the ovs-cni tier1 lane on CNAO
