### PR TITLE
ci, Use vendored-go in functest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,8 +38,8 @@ docker-test:
 test-%: $(GO)
 	$(GO) test ./$(subst -,/,$*)/... -v --ginkgo.v
 
-functest:
-	hack/functests.sh
+functest: $(GO)
+	GO=$(GO) hack/functests.sh
 
 docker-build: $(patsubst %, docker-build-%, $(COMPONENTS))
 

--- a/hack/functests.sh
+++ b/hack/functests.sh
@@ -21,4 +21,4 @@ set -e
 source ./cluster/kubevirtci.sh
 
 KUBECONFIG=${KUBECONFIG:-$(kubevirtci::kubeconfig)}
-go test ./tests/... $E2E_TEST_ARGS --kubeconfig ${KUBECONFIG}
+${GO} test ./tests/... $E2E_TEST_ARGS --kubeconfig ${KUBECONFIG}


### PR DESCRIPTION
Currently we cannot run functests if the host 
doesn't have go installed. 
We want to be independent of this while running tests.
Added vendored-go in functest make target