### PR TITLE
fix golint warnings

### DIFF
--- a/automation/check-patch.e2e.sh
+++ b/automation/check-patch.e2e.sh
@@ -17,6 +17,9 @@ main() {
     source automation/setup.sh
     cd ${TMP_PROJECT_PATH}
 
+    echo 'Run golint'
+    make lint
+
     echo 'Run functional tests'
     make docker-test
 

--- a/pkg/marker/marker.go
+++ b/pkg/marker/marker.go
@@ -41,12 +41,14 @@ type patchOperation struct {
 	Value interface{} `json:"value,omitempty"`
 }
 
+// Marker object containing k8s in cluster api and ovs config
 type Marker struct {
 	nodeName  string
 	clientset kubernetes.Interface
 	ovsdb     *ovsdb.OvsDriver
 }
 
+// NewMarker creates new Marker object
 func NewMarker(nodeName string, ovsSocket string) (*Marker, error) {
 	config, err := rest.InClusterConfig()
 	if err != nil {
@@ -90,7 +92,7 @@ func (m *Marker) getReportedResources() (map[string]bool, error) {
 		return nil, fmt.Errorf("failed to get node: %v", err)
 	}
 
-	for nodeResourceName, _ := range node.Status.Capacity {
+	for nodeResourceName := range node.Status.Capacity {
 		splitNodeResourceName := strings.Split(nodeResourceName.String(), "/")
 		if len(splitNodeResourceName) == 2 && splitNodeResourceName[0] == resourceNamespace {
 			reportedResources[splitNodeResourceName[1]] = true
@@ -100,6 +102,7 @@ func (m *Marker) getReportedResources() (map[string]bool, error) {
 	return reportedResources, nil
 }
 
+// Update reports ovs bridge status to api server
 func (m *Marker) Update() error {
 	availableResources, err := m.getAvailableResources()
 	if err != nil {
@@ -113,7 +116,7 @@ func (m *Marker) Update() error {
 
 	patchOperations := make([]patchOperation, 0)
 
-	for reportedResource, _ := range reportedResources {
+	for reportedResource := range reportedResources {
 		if _, available := availableResources[reportedResource]; !available {
 			patchOperations = append(patchOperations, patchOperation{
 				Op:   "remove",
@@ -122,7 +125,7 @@ func (m *Marker) Update() error {
 		}
 	}
 
-	for availableResource, _ := range availableResources {
+	for availableResource := range availableResources {
 		if _, reported := reportedResources[availableResource]; !reported {
 			patchOperations = append(patchOperations, patchOperation{
 				Op:    "add",

--- a/pkg/plugin/plugin_test.go
+++ b/pkg/plugin/plugin_test.go
@@ -37,10 +37,10 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-const BRIDGE_NAME = "test-bridge"
-const VLAN_ID = 100
-const MTU = 1456
-const DEFAULT_MTU = 1500
+const bridgeName = "test-bridge"
+const vlanID = 100
+const mtu = 1456
+const defaultMTU = 1500
 
 var _ = BeforeSuite(func() {
 	output, err := exec.Command("ovs-vsctl", "show").CombinedOutput()
@@ -48,16 +48,16 @@ var _ = BeforeSuite(func() {
 })
 
 var _ = AfterSuite(func() {
-	exec.Command("ovs-vsctl", "del-br", "--if-exists", BRIDGE_NAME).Run()
+	exec.Command("ovs-vsctl", "del-br", "--if-exists", bridgeName).Run()
 })
 
 var _ = Describe("CNI Plugin", func() {
 
 	BeforeEach(func() {
-		output, err := exec.Command("ovs-vsctl", "add-br", BRIDGE_NAME).CombinedOutput()
+		output, err := exec.Command("ovs-vsctl", "add-br", bridgeName).CombinedOutput()
 		Expect(err).NotTo(HaveOccurred(), "Failed to create testing OVS bridge: %v", string(output[:]))
 
-		bridgeLink, err := netlink.LinkByName(BRIDGE_NAME)
+		bridgeLink, err := netlink.LinkByName(bridgeName)
 		Expect(err).NotTo(HaveOccurred(), "Interface of testing OVS bridge was not found in the system")
 
 		err = netlink.LinkSetUp(bridgeLink)
@@ -65,7 +65,7 @@ var _ = Describe("CNI Plugin", func() {
 	})
 
 	AfterEach(func() {
-		output, err := exec.Command("ovs-vsctl", "del-br", BRIDGE_NAME).CombinedOutput()
+		output, err := exec.Command("ovs-vsctl", "del-br", bridgeName).CombinedOutput()
 		Expect(err).NotTo(HaveOccurred(), "Failed to remove testing OVS bridge: %v", string(output[:]))
 	})
 
@@ -75,10 +75,9 @@ var _ = Describe("CNI Plugin", func() {
 		if setUnmarshalErr {
 			Expect(err).To(HaveOccurred())
 			return
-		} else {
-			Expect(err).NotTo(HaveOccurred())
 		}
-		By("Calling splitVlanIds method")
+		Expect(err).NotTo(HaveOccurred())
+		By("Calling testSplitVlanIds method")
 		vlanIds, err := splitVlanIds(trunks)
 		if expErr != nil {
 			By("Checking expected error is occurred")
@@ -118,9 +117,6 @@ var _ = Describe("CNI Plugin", func() {
 		Expect(len(result.Interfaces)).To(Equal(2))
 
 		Expect(len(result.IPs)).To(Equal(1))
-
-		By("Checking that IP config in result of ADD command is referencing the container interface index")
-		Expect(result.IPs[0].Interface).To(Equal(current.Int(1)))
 
 		err = targetNs.Do(func(ns.NetNS) error {
 			defer GinkgoRecover()
@@ -182,7 +178,7 @@ var _ = Describe("CNI Plugin", func() {
 		Expect(hostLink.Attrs().HardwareAddr).To(Equal(hostHwaddr))
 
 		By("Checking that the host iface is connected as a port to the bridge")
-		brPorts, err := listBridgePorts(BRIDGE_NAME)
+		brPorts, err := listBridgePorts(bridgeName)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(brPorts).To(Equal([]string{hostIface.Name}))
 
@@ -190,15 +186,15 @@ var _ = Describe("CNI Plugin", func() {
 		portVlan, err := getPortAttribute(hostIface.Name, "tag")
 		Expect(err).NotTo(HaveOccurred())
 		if setVlan {
-			Expect(portVlan).To(Equal(strconv.Itoa(VLAN_ID)))
+			Expect(portVlan).To(Equal(strconv.Itoa(vlanID)))
 		} else {
 			Expect(portVlan).To(Equal("[]"))
 		}
 
 		if setMtu {
-			Expect(hostLink.Attrs().MTU).To(Equal(MTU))
+			Expect(hostLink.Attrs().MTU).To(Equal(mtu))
 		} else {
-			Expect(hostLink.Attrs().MTU).To(Equal(DEFAULT_MTU))
+			Expect(hostLink.Attrs().MTU).To(Equal(defaultMTU))
 		}
 
 		By("Checking that Trunk VLAN range matches expected state")
@@ -209,14 +205,14 @@ var _ = Describe("CNI Plugin", func() {
 		}
 
 		By("Checking that port external-id:contIface contains reference to container interface name")
-		externalIdContIface, err := getPortAttribute(hostIface.Name, "external-ids:contIface")
+		externalIDContIface, err := getPortAttribute(hostIface.Name, "external-ids:contIface")
 		Expect(err).NotTo(HaveOccurred())
-		Expect(externalIdContIface).To(Equal(contIface.Name))
+		Expect(externalIDContIface).To(Equal(contIface.Name))
 
 		By("Checking that port external-id:contNetns contains reference to container namespace path")
-		externalIdContNetns, err := getPortAttribute(hostIface.Name, "external-ids:contNetns")
+		externalIDContNetns, err := getPortAttribute(hostIface.Name, "external-ids:contNetns")
 		Expect(err).NotTo(HaveOccurred())
-		Expect(externalIdContNetns).To(Equal("\"" + targetNs.Path() + "\""))
+		Expect(externalIDContNetns).To(Equal("\"" + targetNs.Path() + "\""))
 
 		By("Verifying situation inside the container")
 		err = targetNs.Do(func(ns.NetNS) error {
@@ -235,9 +231,9 @@ var _ = Describe("CNI Plugin", func() {
 			Expect(contLink.Attrs().OperState).To(Equal(netlink.LinkOperState(netlink.OperUp)))
 
 			if setMtu {
-				Expect(contLink.Attrs().MTU).To(Equal(MTU))
+				Expect(contLink.Attrs().MTU).To(Equal(mtu))
 			} else {
-				Expect(contLink.Attrs().MTU).To(Equal(DEFAULT_MTU))
+				Expect(contLink.Attrs().MTU).To(Equal(defaultMTU))
 			}
 
 			return nil
@@ -269,7 +265,7 @@ var _ = Describe("CNI Plugin", func() {
 		Expect(hostLink).To(BeNil())
 
 		By("Checking that the port on OVS bridge was deleted")
-		brPorts, err = listBridgePorts(BRIDGE_NAME)
+		brPorts, err = listBridgePorts(bridgeName)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(len(brPorts)).To(Equal(0))
 	}
@@ -282,7 +278,7 @@ var _ = Describe("CNI Plugin", func() {
 				"type": "ovs",
 				"bridge": "%s",
 				"vlan": %d
-			}`, BRIDGE_NAME, VLAN_ID)
+			}`, bridgeName, vlanID)
 			It("should successfully complete ADD and DEL commands", func() {
 				testAddDel(conf, true, false, "")
 			})
@@ -293,7 +289,7 @@ var _ = Describe("CNI Plugin", func() {
 				"name": "mynet",
 				"type": "ovs",
 				"bridge": "%s"
-			}`, BRIDGE_NAME)
+			}`, bridgeName)
 			It("should successfully complete ADD and DEL commands", func() {
 				testAddDel(conf, false, false, "")
 			})
@@ -305,7 +301,7 @@ var _ = Describe("CNI Plugin", func() {
 				"type": "ovs",
 				"bridge": "%s",
 				"trunk": [ {"minID": 10, "maxID": 12}, {"id": 15}, {"minID": 17, "maxID": 18}  ]
-			}`, BRIDGE_NAME)
+			}`, bridgeName)
 			It("should successfully complete ADD and DEL commands", func() {
 				testAddDel(conf, false, false, "[10, 11, 12, 15, 17, 18]")
 			})
@@ -320,7 +316,7 @@ var _ = Describe("CNI Plugin", func() {
 					"type": "host-local",
 					"ranges": [[ {"subnet": "10.1.2.0/24", "gateway": "10.1.2.1"} ]]
 				}
-			}`, BRIDGE_NAME)
+			}`, bridgeName)
 			It("should successfully complete ADD and DEL commands", func() {
 				testIPAM(conf, "10.1.2")
 			})
@@ -332,7 +328,7 @@ var _ = Describe("CNI Plugin", func() {
 				"type": "ovs",
 				"bridge": "%s",
 				"mtu": %d
-			}`, BRIDGE_NAME, MTU)
+			}`, bridgeName, mtu)
 			It("should successfully complete ADD and DEL commands", func() {
 				testAddDel(conf, false, true, "")
 			})
@@ -345,7 +341,7 @@ var _ = Describe("CNI Plugin", func() {
 				"type": "ovs",
 				"bridge": "%s",
 				"vlan": %d
-				}`, BRIDGE_NAME, VLAN_ID)
+				}`, bridgeName, vlanID)
 
 				const IFNAME = "eth0"
 
@@ -375,7 +371,7 @@ var _ = Describe("CNI Plugin", func() {
 				"type": "ovs",
 				"bridge": "%s",
 				"vlan": %d
-				}`, BRIDGE_NAME, VLAN_ID)
+				}`, bridgeName, vlanID)
 
 				const IFNAME = "eth0"
 
@@ -402,7 +398,7 @@ var _ = Describe("CNI Plugin", func() {
 				"name": "mynet",
 				"type": "ovs",
 				"OvnPort": "test-port",
-				"bridge": "%s"}`, BRIDGE_NAME)
+				"bridge": "%s"}`, bridgeName)
 
 				targetNs, err := testutils.NewNS()
 				Expect(err).NotTo(HaveOccurred())
@@ -461,7 +457,7 @@ var _ = Describe("CNI Plugin", func() {
 				"name": "mynet",
 				"type": "ovs",
 				"OvnPort": "test-port",
-				"bridge": "%s"}`, BRIDGE_NAME)
+				"bridge": "%s"}`, bridgeName)
 
 			It("DEL removes ports without network namespace", func() {
 				firstTargetNs, err := testutils.NewNS()

--- a/pkg/plugin/plugin_test.go
+++ b/pkg/plugin/plugin_test.go
@@ -118,6 +118,9 @@ var _ = Describe("CNI Plugin", func() {
 
 		Expect(len(result.IPs)).To(Equal(1))
 
+		By("Checking that IP config in result of ADD command is referencing the container interface index")
+		Expect(result.IPs[0].Interface).To(Equal(current.Int(1)))
+
 		err = targetNs.Do(func(ns.NetNS) error {
 			defer GinkgoRecover()
 

--- a/tests/node/node.go
+++ b/tests/node/node.go
@@ -28,6 +28,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
+// RunOnNode performs bash shell command on node
 // TODO: Use job with a node affinity instead
 func RunOnNode(node string, command string) (string, error) {
 	out, err := exec.Command("bash", "-c", fmt.Sprintf("docker ps | grep %s | awk '{ print $1}'", node)).CombinedOutput()
@@ -48,12 +49,14 @@ func RunOnNode(node string, command string) (string, error) {
 	return outStrippedString, err
 }
 
+// RemoveOvsBridgeOnNode removes ovs bridge on the node
 func RemoveOvsBridgeOnNode(bridgeName string) {
 	By("Removing ovs-bridge on the node")
 	out, err := RunOnNode("node01", "sudo ovs-vsctl --if-exists del-br "+bridgeName)
 	Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("Failed to run command on node. stdout: %s", out))
 }
 
+// AddOvsBridgeOnNode add ovs bridge on the node
 func AddOvsBridgeOnNode(bridgeName string) {
 	By("Adding ovs-bridge on the node")
 	out, err := RunOnNode("node01", "sudo ovs-vsctl add-br "+bridgeName)

--- a/tests/ovs_test.go
+++ b/tests/ovs_test.go
@@ -65,8 +65,8 @@ var _ = Describe("ovs-cni", func() {
 						cidrPod2 = "10.0.0.2/24"
 					)
 					BeforeEach(func() {
-						clusterApi.CreatePrivilegedPodWithIp(pod1Name, nadName, bridgeName, cidrPod1)
-						clusterApi.CreatePrivilegedPodWithIp(pod2Name, nadName, bridgeName, cidrPod2)
+						clusterApi.CreatePrivilegedPodWithIP(pod1Name, nadName, bridgeName, cidrPod1)
+						clusterApi.CreatePrivilegedPodWithIP(pod2Name, nadName, bridgeName, cidrPod2)
 					})
 					AfterEach(func() {
 						clusterApi.DeletePodsInTestNamespace()

--- a/tests/tests_suite_test.go
+++ b/tests/tests_suite_test.go
@@ -27,7 +27,7 @@ import (
 )
 
 var kubeconfig *string
-var clusterApi *clusterapi.ClusterApi
+var clusterApi *clusterapi.ClusterAPI
 
 func TestPlugin(t *testing.T) {
 	RegisterFailHandler(Fail)
@@ -41,7 +41,7 @@ func TestPlugin(t *testing.T) {
 var _ = BeforeSuite(func() {
 	flag.Parse()
 
-	clusterApi = clusterapi.NewClusterApi(*kubeconfig)
+	clusterApi = clusterapi.NewClusterAPI(*kubeconfig)
 	clusterApi.RemoveTestNamespace()
 	clusterApi.CreateTestNamespace()
 })


### PR DESCRIPTION
This fixes golint code style warnings across go modules in the project.
It is makes golint a mandatory prerequisite for CI to pass.

Signed-off-by: Periyasamy Palanisamy <periyasamy.palanisamy@est.tech>