### PR TITLE
update deprecated api version

### DIFF
--- a/examples/ovs-cni.yml
+++ b/examples/ovs-cni.yml
@@ -64,7 +64,7 @@ spec:
             path: /var/run/openvswitch
 ---
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: ovs-cni-marker-cr
 rules:
@@ -79,7 +79,7 @@ rules:
   - patch
 ---
 kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: ovs-cni-marker-crb
 roleRef:

--- a/manifests/ovs-cni.yml.in
+++ b/manifests/ovs-cni.yml.in
@@ -64,7 +64,7 @@ spec:
             path: /var/run/openvswitch
 ---
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: ovs-cni-marker-cr
 rules:
@@ -79,7 +79,7 @@ rules:
   - patch
 ---
 kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: ovs-cni-marker-crb
 roleRef:


### PR DESCRIPTION
This updates ClusterRole/ClusterRoleBinding kind apiVersion into `v1 `because `v1beta1 `
is already deprecated in K8s 1.17 and deployment of [ovs-cni.yml](https://github.com/kubevirt/ovs-cni/blob/master/examples/ovs-cni.yml) throws below warning.

```
Warning: rbac.authorization.k8s.io/v1beta1 ClusterRole is deprecated in v1.17+, unavailable in v1.22+; use rbac.authorization.k8s.io/v1 ClusterRole
Warning: rbac.authorization.k8s.io/v1beta1 ClusterRoleBinding is deprecated in v1.17+, unavailable in v1.22+; use rbac.authorization.k8s.io/v1 ClusterRoleBinding
```

Signed-off-by: Periyasamy Palanisamy <periyasamy.palanisamy@est.tech>