### PR TITLE
make ovs socket file path as configurable property

### DIFF
--- a/docs/cni-plugin.md
+++ b/docs/cni-plugin.md
@@ -45,6 +45,35 @@ Another example with a trunk port and jumbo frames:
 * `mtu` (integer, optional): MTU.
 * `trunk` (optional): List of VLAN ID's and/or ranges of accepted VLAN
   ID's.
+* `configuration_path` (optional): configuration file containing ovsdb
+  socket file path, etc.
+
+### Flatfile Configuation
+
+There is one option for flat file configuration:
+
+* `configuration_path`: A file path to a OVS CNI configuration file.
+
+OVS CNI will look for the configuration in these locations, in this order:
+
+* The location specified by the `configuration_path` option.
+* `/etc/kubernetes/cni/net.d/ovs.d/ovs.conf`
+* `/etc/cni/net.d/ovs.d/ovs.conf`
+
+You may specify the `configuration_path` to point to another location should it be desired.
+
+Any options added to the `ovs.conf` are overridden by configuration options that are in the
+CNI configuration (e.g. in a custom resource `NetworkAttachmentDefinition` used by Multus CNI
+or in the first file ASCII-betically in the CNI configuration directory -- which is
+`/etc/cni/net.d/` by default).
+
+The sample content of ovs.conf (in JSON format) is as follows:
+
+```json
+{
+  "socket_file": "/usr/local/var/run/openvswitch/db.sock"
+}
+```
 
 ## Manual Testing
 

--- a/docs/cni-plugin.md
+++ b/docs/cni-plugin.md
@@ -64,7 +64,7 @@ You may specify the `configuration_path` to point to another location should it 
 
 Any options added to the `ovs.conf` are overridden by configuration options that are in the
 CNI configuration (e.g. in a custom resource `NetworkAttachmentDefinition` used by Multus CNI
-or in the first file "ASCII-betically" in the CNI configuration directory -- which is
+or in the first file ASCII-betically in the CNI configuration directory -- which is
 `/etc/cni/net.d/` by default).
 
 The sample content of ovs.conf (in JSON format) is as follows:

--- a/docs/cni-plugin.md
+++ b/docs/cni-plugin.md
@@ -64,7 +64,7 @@ You may specify the `configuration_path` to point to another location should it 
 
 Any options added to the `ovs.conf` are overridden by configuration options that are in the
 CNI configuration (e.g. in a custom resource `NetworkAttachmentDefinition` used by Multus CNI
-or in the first file ASCII-betically in the CNI configuration directory -- which is
+or in the first file "ASCII-betically" in the CNI configuration directory -- which is
 `/etc/cni/net.d/` by default).
 
 The sample content of ovs.conf (in JSON format) is as follows:

--- a/pkg/ovsdb/ovsdb.go
+++ b/pkg/ovsdb/ovsdb.go
@@ -53,12 +53,16 @@ func NewOvsDriver(ovsSocket string) (*OvsDriver, error) {
 }
 
 // Create a new OVS driver for a bridge with Unix socket
-func NewOvsBridgeDriver(bridgeName string) (*OvsBridgeDriver, error) {
+func NewOvsBridgeDriver(bridgeName, socketFile string) (*OvsBridgeDriver, error) {
 	ovsDriver := new(OvsBridgeDriver)
 
-	ovsDB, err := libovsdb.ConnectWithUnixSocket("/var/run/openvswitch/db.sock")
+	if socketFile == "" {
+		socketFile = "/var/run/openvswitch/db.sock"
+	}
+
+	ovsDB, err := libovsdb.ConnectWithUnixSocket(socketFile)
 	if err != nil {
-		return nil, fmt.Errorf("failed to connect to ovsdb error: %v", err)
+		return nil, fmt.Errorf("failed to connect to ovsdb socket %s: error: %v", socketFile, err)
 	}
 
 	// Setup state

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -118,30 +118,30 @@ func loadNetConf(bytes []byte) (*netConf, error) {
 }
 
 func loadFlatNetConf(configPath string) (*netConf, error) {
-	confDirs := getOvsConfDir()
+	confFiles := getOvsConfFiles()
 	if configPath != "" {
-		confDirs = append([]string{configPath}, confDirs...)
+		confFiles = append([]string{configPath}, confFiles...)
 	}
 
 	// loop through the path and parse the JSON config
 	flatNetConf := &netConf{}
-	for _, confPath := range confDirs {
-		confExists, err := pathExists(confPath)
+	for _, confFile := range confFiles {
+		confExists, err := pathExists(confFile)
 		if err != nil {
 			return nil, fmt.Errorf("error checking ovs config file: error: %v", err)
 		}
 		if confExists {
-			jsonFile, err := os.Open(confPath)
+			jsonFile, err := os.Open(confFile)
 			if err != nil {
-				return nil, fmt.Errorf("open ovs config file %s error: %v", confPath, err)
+				return nil, fmt.Errorf("open ovs config file %s error: %v", confFile, err)
 			}
 			defer jsonFile.Close()
 			jsonBytes, err := ioutil.ReadAll(jsonFile)
 			if err != nil {
-				return nil, fmt.Errorf("load ovs config file %s: error: %v", confPath, err)
+				return nil, fmt.Errorf("load ovs config file %s: error: %v", confFile, err)
 			}
 			if err := json.Unmarshal(jsonBytes, flatNetConf); err != nil {
-				return nil, fmt.Errorf("parse ovs config file %s: error: %v", confPath, err)
+				return nil, fmt.Errorf("parse ovs config file %s: error: %v", confFile, err)
 			}
 			break
 		}
@@ -168,7 +168,7 @@ func pathExists(path string) (bool, error) {
 	return false, err
 }
 
-func getOvsConfDir() []string {
+func getOvsConfFiles() []string {
 	return []string{"/etc/kubernetes/cni/net.d/ovs.d/ovs.conf", "/etc/cni/net.d/ovs.d/ovs.conf"}
 }
 


### PR DESCRIPTION
The ovs-cni currently hardcodes the ovs unix socket file path to `/var/run/openvswitch/db.sock`.
But this would change across deployments. Hence introducing a global flat file configuration so that
`socket_file`  path can be specified and this is applied for all network attachment definition objects.

Signed-off-by: Periyasamy Palanisamy <periyasamy.palanisamy@est.tech>