### PR TITLE
parse flat net config in cmd delete call

### DIFF
--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -542,6 +542,14 @@ func CmdDel(args *skel.CmdArgs) error {
 	if err != nil {
 		return err
 	}
+	flatNetConf, err := loadFlatNetConf(netconf.ConfigurationPath)
+	if err != nil {
+		return err
+	}
+	netconf, err = mergeConf(netconf, flatNetConf)
+	if err != nil {
+		return err
+	}
 
 	bridgeName, err := getBridgeName(netconf.BrName, ovnPort)
 	if err != nil {


### PR DESCRIPTION
This is a regression fix and would make `CmdDel `not to fail when ovs socket file is in different directory
other than `/var/run/openvswitch/`.

Signed-off-by: Periyasamy Palanisamy <periyasamy.palanisamy@est.tech>