### PR TITLE
Fix segfault when SR-IOV or veth interface failed to create

### DIFF
--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -391,9 +391,15 @@ func CmdAdd(args *skel.CmdArgs) error {
 	if netconf.DeviceID != "" {
 		// SR-IOV Case
 		hostIface, contIface, err = sriov.SetupSriovInterface(contNetns, args.ContainerID, args.IfName, netconf.MTU, netconf.DeviceID)
+		if err != nil {
+			return err
+		}
 	} else {
 		// General Case
 		hostIface, contIface, err = setupVeth(contNetns, args.IfName, mac, netconf.MTU)
+		if err != nil {
+			return err
+		}
 	}
 
 	if err = attachIfaceToBridge(ovsDriver, hostIface.Name, contIface.Name, vlanTagNum, trunks, portType, args.Netns, ovnPort); err != nil {


### PR DESCRIPTION
This commit add the missing error check when creating SR-IOV or veth
interface.

Signed-off-by: Moshe Levi <moshele@nvidia.com>