### PR TITLE
[WIP] configure vlan sub interfaces

### DIFF
--- a/examples/ovs-net-vlan-ipam.yml
+++ b/examples/ovs-net-vlan-ipam.yml
@@ -1,0 +1,46 @@
+apiVersion: "k8s.cni.cncf.io/v1"
+kind: NetworkAttachmentDefinition
+metadata:
+  name: ovs-cni-net
+spec:
+  config: '{
+  "cniVersion": "0.3.1",
+  "type": "ovs",
+  "bridge": "br0",
+  "ipam": {
+    "type": "host-local",
+    "subnet": "192.168.0.0/24",
+    "rangeStart": "192.168.0.200",
+    "rangeEnd": "192.168.0.216",
+    "routes": [
+      { "dst": "0.0.0.0/0" }
+    ],
+    "gateway": "192.168.0.1"
+  },
+  "trunk": [
+            { "id" : 42,
+              "ipam": {
+                "type": "host-local",
+                "subnet": "192.168.42.0/24",
+                "rangeStart": "192.168.42.200",
+                "rangeEnd": "192.168.42.216",
+                "routes": [
+                  { "dst": "0.0.0.0/0" }
+                ],
+                "gateway": "192.168.42.1"
+              }
+            },
+            { "id" : 50,
+              "ipam": {
+                "type": "host-local",
+                "subnet": "192.168.50.0/24",
+                "rangeStart": "192.168.50.200",
+                "rangeEnd": "192.168.50.216",
+                "routes": [
+                  { "dst": "0.0.0.0/0" }
+                ],
+                "gateway": "192.168.50.1"
+              }
+            }
+  ]
+}'

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -54,33 +54,33 @@ const (
 
 type netConf struct {
 	types.NetConf
-	BrName            string      `json:"bridge,omitempty"`
-	IPAM              *ipamConfig `json:"ipam,omitempty"`
-	VlanTag           *uint       `json:"vlan"`
-	MTU               int         `json:"mtu"`
-	Trunk             []*trunk    `json:"trunk,omitempty"`
-	DeviceID          string      `json:"deviceID"` // PCI address of a VF in valid sysfs format
-	ConfigurationPath string      `json:"configuration_path"`
-	SocketFile        string      `json:"socket_file"`
+	BrName            string   `json:"bridge,omitempty"`
+	IPAM              *IPAM    `json:"ipam,omitempty"`
+	VlanTag           *uint    `json:"vlan"`
+	MTU               int      `json:"mtu"`
+	Trunk             []*trunk `json:"trunk,omitempty"`
+	DeviceID          string   `json:"deviceID"` // PCI address of a VF in valid sysfs format
+	ConfigurationPath string   `json:"configuration_path"`
+	SocketFile        string   `json:"socket_file"`
 }
 
 type trunk struct {
-	MinID *uint       `json:"minID,omitempty"`
-	MaxID *uint       `json:"maxID,omitempty"`
-	ID    *uint       `json:"id,omitempty"`
-	IPAM  *ipamConfig `json:"ipam,omitempty"`
+	MinID *uint `json:"minID,omitempty"`
+	MaxID *uint `json:"maxID,omitempty"`
+	ID    *uint `json:"id,omitempty"`
+	IPAM  *IPAM `json:"ipam,omitempty"`
 }
 
-type ipamConfig struct {
-	*ipRange
+type IPAM struct {
+	*Range
 	Type   string         `json:"type,omitempty"`
 	Routes []*types.Route `json:"routes,omitempty"`
-	Ranges []rangeSet     `json:"ranges,omitempty"`
+	Ranges []RangeSet     `json:"ranges,omitempty"`
 }
 
-type rangeSet []ipRange
+type RangeSet []Range
 
-type ipRange struct {
+type Range struct {
 	RangeStart net.IP      `json:"rangeStart,omitempty"` // The first ip, inclusive
 	RangeEnd   net.IP      `json:"rangeEnd,omitempty"`   // The last ip, inclusive
 	Subnet     types.IPNet `json:"subnet"`

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -54,33 +54,33 @@ const (
 
 type netConf struct {
 	types.NetConf
-	BrName            string   `json:"bridge,omitempty"`
-	IPAM              *IPAM    `json:"ipam,omitempty"`
-	VlanTag           *uint    `json:"vlan"`
-	MTU               int      `json:"mtu"`
-	Trunk             []*trunk `json:"trunk,omitempty"`
-	DeviceID          string   `json:"deviceID"` // PCI address of a VF in valid sysfs format
-	ConfigurationPath string   `json:"configuration_path"`
-	SocketFile        string   `json:"socket_file"`
+	BrName            string      `json:"bridge,omitempty"`
+	IPAM              *ipamConfig `json:"ipam,omitempty"`
+	VlanTag           *uint       `json:"vlan"`
+	MTU               int         `json:"mtu"`
+	Trunk             []*trunk    `json:"trunk,omitempty"`
+	DeviceID          string      `json:"deviceID"` // PCI address of a VF in valid sysfs format
+	ConfigurationPath string      `json:"configuration_path"`
+	SocketFile        string      `json:"socket_file"`
 }
 
 type trunk struct {
-	MinID *uint `json:"minID,omitempty"`
-	MaxID *uint `json:"maxID,omitempty"`
-	ID    *uint `json:"id,omitempty"`
-	IPAM  *IPAM `json:"ipam,omitempty"`
+	MinID *uint       `json:"minID,omitempty"`
+	MaxID *uint       `json:"maxID,omitempty"`
+	ID    *uint       `json:"id,omitempty"`
+	IPAM  *ipamConfig `json:"ipam,omitempty"`
 }
 
-type IPAM struct {
-	*Range
+type ipamConfig struct {
+	*ipRange
 	Type   string         `json:"type,omitempty"`
 	Routes []*types.Route `json:"routes,omitempty"`
-	Ranges []RangeSet     `json:"ranges,omitempty"`
+	Ranges []rangeSet     `json:"ranges,omitempty"`
 }
 
-type RangeSet []Range
+type rangeSet []ipRange
 
-type Range struct {
+type ipRange struct {
 	RangeStart net.IP      `json:"rangeStart,omitempty"` // The first ip, inclusive
 	RangeEnd   net.IP      `json:"rangeEnd,omitempty"`   // The last ip, inclusive
 	Subnet     types.IPNet `json:"subnet"`

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -71,6 +71,7 @@ type trunk struct {
 	IPAM  *IPAM `json:"ipam,omitempty"`
 }
 
+// IPAM ipam configuration
 type IPAM struct {
 	*Range
 	Type   string         `json:"type,omitempty"`
@@ -78,8 +79,10 @@ type IPAM struct {
 	Ranges []RangeSet     `json:"ranges,omitempty"`
 }
 
+// RangeSet ip range set
 type RangeSet []Range
 
+// Range ip range configuration
 type Range struct {
 	RangeStart net.IP      `json:"rangeStart,omitempty"` // The first ip, inclusive
 	RangeEnd   net.IP      `json:"rangeEnd,omitempty"`   // The last ip, inclusive

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -220,7 +220,7 @@ func setupTrunkIfaces(netconf *netConf, contNetns ns.NetNS, contIfaceName string
 	origIPAMConfig := netconf.IPAM
 	err := contNetns.Do(func(hostNetns ns.NetNS) error {
 		for _, trunk := range netconf.Trunk {
-			if trunk.IPAM.Type == "" {
+			if trunk.IPAM == nil || trunk.IPAM.Type == "" {
 				continue
 			}
 			subIfName := contIfaceName + "." + fmt.Sprint(*trunk.ID)
@@ -284,7 +284,7 @@ func setupTrunkIfaces(netconf *netConf, contNetns ns.NetNS, contIfaceName string
 func cleanupTrunkIfaces(netconf *netConf) error {
 	origIPAMConfig := netconf.IPAM
 	for _, trunk := range netconf.Trunk {
-		if trunk.IPAM.Type == "" {
+		if trunk.IPAM == nil || trunk.IPAM.Type == "" {
 			continue
 		}
 		netconf.IPAM = trunk.IPAM
@@ -590,7 +590,7 @@ func CmdAdd(args *skel.CmdArgs) error {
 	}
 
 	// run the IPAM plugin
-	if netconf.IPAM.Type != "" {
+	if netconf.IPAM != nil && netconf.IPAM.Type != "" {
 		r, err := ipam.ExecAdd(netconf.IPAM.Type, args.StdinData)
 		if err != nil {
 			return fmt.Errorf("failed to set up IPAM plugin type %q: %v", netconf.IPAM.Type, err)
@@ -762,7 +762,7 @@ func CmdDel(args *skel.CmdArgs) error {
 		return err
 	}
 
-	if netconf.IPAM.Type != "" {
+	if netconf.IPAM != nil && netconf.IPAM.Type != "" {
 		err = ipam.ExecDel(netconf.IPAM.Type, args.StdinData)
 		if err != nil {
 			return err


### PR DESCRIPTION
Currently ovs-cni supports selective vlan trunking in the networking configuration and creates ovs port on host ovs bridge with given selective trunk vlan IDs. But the vlan handling on the pod container is upto the applications like creating vlan sub interfaces, ip assignment etc. 

This PR attempts to solve this by enhancing ovs-cni to accept IPAM configuration for every VLAN and let ovs-cni creates vlan sub interface and invokes relevant IPAM plugin for every vlan ID for the ip assignment. Of course we could also provide an option in net-attach-def not to create vlan sub interface for every vlan ID in trunks parameter. This is just an initial PR and  would make changes accordingly based on your feedback.

The multus-cni and network-attachment-definition-clients need code changes to report all interfaces with ip information in the nw status, will raise PRs on those repos and get their opinon.

/cc @JanScheurich